### PR TITLE
fix ecdsa signature serialization and parsing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             pkgConfig: "openssl",
             providers: [
                 .apt(["openssl libssl-dev"]),
-                .brew(["openssl"])
+                .brew(["openssl@1.1"])
             ]
         ),
         .target(name: "CJWTKitCrypto", dependencies: ["CJWTKitOpenSSL"]),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             pkgConfig: "openssl",
             providers: [
                 .apt(["openssl libssl-dev"]),
-                .brew(["openssl@1.1"])
+                .brew(["openssl"])
             ]
         ),
         .target(name: "CJWTKitCrypto", dependencies: ["CJWTKitOpenSSL"]),

--- a/Sources/CJWTKitCrypto/c_jwtkit_crypto.c
+++ b/Sources/CJWTKitCrypto/c_jwtkit_crypto.c
@@ -4,7 +4,7 @@
 int jwtkit_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
     sig->r = r;
     sig->s = s;
-    return 0;
+    return 1;
 }
 
 const BIGNUM *jwtkit_ECDSA_SIG_get0_r(const ECDSA_SIG *sig) {

--- a/Sources/CJWTKitCrypto/c_jwtkit_crypto.c
+++ b/Sources/CJWTKitCrypto/c_jwtkit_crypto.c
@@ -1,6 +1,20 @@
 #include "include/c_jwtkit_crypto.h"
 
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+int jwtkit_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
+    sig->r = r;
+    sig->s = s;
+    return 0;
+}
+
+const BIGNUM *jwtkit_ECDSA_SIG_get0_r(const ECDSA_SIG *sig) {
+    return sig->r;
+};
+
+const BIGNUM *jwtkit_ECDSA_SIG_get0_s(const ECDSA_SIG *sig) {
+    return sig->s;
+};
+
 EVP_MD_CTX *jwtkit_EVP_MD_CTX_new(void) {
     return EVP_MD_CTX_create();
 };
@@ -21,6 +35,18 @@ void jwtkit_HMAC_CTX_free(HMAC_CTX *ctx) {
     free(ctx);
 };
 #else
+int jwtkit_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
+    return ECDSA_SIG_set0(sig, r, s);
+}
+
+const BIGNUM *jwtkit_ECDSA_SIG_get0_r(const ECDSA_SIG *sig) {
+    return ECDSA_SIG_get0_r(sig);
+};
+
+const BIGNUM *jwtkit_ECDSA_SIG_get0_s(const ECDSA_SIG *sig) {
+    return ECDSA_SIG_get0_s(sig);
+};
+
 EVP_MD_CTX *jwtkit_EVP_MD_CTX_new(void) {
     return EVP_MD_CTX_new();
 };

--- a/Sources/CJWTKitCrypto/include/c_jwtkit_crypto.h
+++ b/Sources/CJWTKitCrypto/include/c_jwtkit_crypto.h
@@ -18,5 +18,8 @@ EVP_MD_CTX *jwtkit_EVP_MD_CTX_new(void);
 void jwtkit_EVP_MD_CTX_free(EVP_MD_CTX *ctx);
 HMAC_CTX *jwtkit_HMAC_CTX_new(void);
 void jwtkit_HMAC_CTX_free(HMAC_CTX *ctx);
+int jwtkit_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
+const BIGNUM *jwtkit_ECDSA_SIG_get0_r(const ECDSA_SIG *sig);
+const BIGNUM *jwtkit_ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
 
 #endif

--- a/Sources/JWTKit/JWTSigner+ECDSA.swift
+++ b/Sources/JWTKit/JWTSigner+ECDSA.swift
@@ -114,6 +114,10 @@ private struct ECDSASigner: JWTAlgorithm, OpenSSLSigner {
         // parse r+s values
         // see: https://tools.ietf.org/html/rfc7515#appendix-A.3
         let signatureBytes = signature.copyBytes()
+        guard signatureBytes.count == 64 else {
+            return false
+        }
+
         let rb = signatureBytes[0..<32].copyBytes()
         let sb = signatureBytes[32..<64].copyBytes()
 

--- a/Sources/JWTKit/JWTSigner+ECDSA.swift
+++ b/Sources/JWTKit/JWTSigner+ECDSA.swift
@@ -129,7 +129,7 @@ private struct ECDSASigner: JWTAlgorithm, OpenSSLSigner {
                     signature,
                     BN_bin2bn(r.baseAddress, 32, nil),
                     BN_bin2bn(s.baseAddress, 32, nil)
-                ) == 0 else {
+                ) == 1 else {
                     fatalError("ECDSA_SIG_set failed")
                 }
             }

--- a/Tests/JWTKitTests/XCTestManifests.swift
+++ b/Tests/JWTKitTests/XCTestManifests.swift
@@ -11,6 +11,7 @@ extension JWTKitTests {
         ("testExpirationDecoding", testExpirationDecoding),
         ("testExpirationEncoding", testExpirationEncoding),
         ("testExpired", testExpired),
+        ("testJWTioExample", testJWTioExample),
         ("testParse", testParse),
         ("testRSA", testRSA),
         ("testRSASignWithPublic", testRSASignWithPublic),


### PR DESCRIPTION
Prior to this fix, ECDSA signatures were encoded incorrectly as DER. This change fixes the encoding to be a concatenation of the R and S values according to the spec: https://tools.ietf.org/html/rfc7515#appendix-A.3. 

This PR also adds a test against a known-correct value from JWT.io to ensure adherence to the spec.

Fixes #100. 