### PR TITLE
Fixed warning: 'public' modifier is redundant for initializer declared in a public extension

### DIFF
--- a/Sources/JWT/JWK+KeyOperation.swift
+++ b/Sources/JWT/JWK+KeyOperation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public extension JWK {
+extension JWK {
     public enum KeyOperation: String, Codable {
         /// Compute digital signature or MAC.
         case sign

--- a/Sources/JWT/JWK.swift
+++ b/Sources/JWT/JWK.swift
@@ -155,7 +155,7 @@ public struct JWK: Codable {
     }
 }
 
-public extension JWTSigner {
+extension JWTSigner {
 
     /// Creates a JWT signer with the supplied JWK
     public static func jwk(key: JWK) throws -> JWTSigner {

--- a/Sources/JWT/JWKS.swift
+++ b/Sources/JWT/JWKS.swift
@@ -13,7 +13,7 @@ public struct JWKS: Codable {
     }
 }
 
-public extension JWTSigners {
+extension JWTSigners {
 
     public convenience init(jwks: JWKS, skipAnonymousKeys: Bool = true) throws  {
         self.init()


### PR DESCRIPTION
Fixed warning: 'public' modifier is redundant for initializer declared in a public extension.