### PR TITLE
Fix Payload Verification

### DIFF
--- a/Sources/JWTKit/JWTSigner.swift
+++ b/Sources/JWTKit/JWTSigner.swift
@@ -48,7 +48,15 @@ public final class JWTSigner {
         where Message: DataProtocol, Payload: JWTPayload
     {
         let parser = try JWTParser(token: token)
+        return try self.verify(parser: parser)
+    }
+
+    func verify<Payload>(parser: JWTParser) throws -> Payload
+        where Payload: JWTPayload
+    {
         try parser.verify(using: self)
-        return try parser.payload(as: Payload.self)
+        let payload = try parser.payload(as: Payload.self)
+        try payload.verify(using: self)
+        return payload
     }
 }

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -84,8 +84,7 @@ public final class JWTSigners {
     {
         let parser = try JWTParser(token: token)
         let header = try parser.header()
-        try parser.verify(using: self.require(kid: header.kid))
-        return try parser.payload(as: Payload.self)
+        return try self.require(kid: header.kid).verify(parser: parser)
     }
 
     public func sign<Payload>(

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -230,6 +230,23 @@ class JWTKitTests: XCTestCase {
         XCTAssertEqual(a.algorithm.name, "RS256")
         XCTAssertEqual(b.algorithm.name, "RS512")
     }
+
+    func testJWTPayloadVerification() throws {
+        struct Payload: JWTPayload {
+            let foo: String
+            static var didVerify = false
+            func verify(using signer: JWTSigner) throws {
+                Self.didVerify = true
+            }
+        }
+
+        let signer = try JWTSigner.es256(key: .generate())
+        let token = try signer.sign(Payload(foo: "bar"))
+        XCTAssertEqual(Payload.didVerify, false)
+        let payload = try signer.verify(token, as: Payload.self)
+        XCTAssertEqual(payload.foo, "bar")
+        XCTAssertEqual(Payload.didVerify, true)
+    }
 }
 
 struct TestPayload: JWTPayload, Equatable {


### PR DESCRIPTION
JWT verification using `JWTSigner` and `JWTSigners` now correctly invokes `JWTPayload`'s optional `verify` method. (#6)