### PR TITLE
BoolClaim handles strings

### DIFF
--- a/Sources/JWTKit/Claims/BoolClaim.swift
+++ b/Sources/JWTKit/Claims/BoolClaim.swift
@@ -17,4 +17,19 @@ public struct BoolClaim: JWTClaim, Equatable, ExpressibleByStringLiteral, Expres
     public init(booleanLiteral value: Bool) {
         self.value = value
     }
+
+    public init(from decoder: Decoder) throws {
+        let single = try decoder.singleValueContainer()
+
+        do {
+            try self.init(value: single.decode(Bool.self))
+        } catch {
+            let str = try single.decode(String.self)
+            guard let bool = Bool(str) else {
+                throw JWTError.invalidBool(str)
+            }
+
+            self.init(value: bool)
+        }
+    }
 }

--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -8,6 +8,7 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
     case missingKIDHeader
     case unknownKID(JWKIdentifier)
     case invalidJWK
+    case invalidBool(String)
 
     public var reason: String {
         switch self {
@@ -25,6 +26,8 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
             return "unknown kid: \(kid)"
         case .invalidJWK:
             return "invalid JWK"
+        case .invalidBool(let str):
+            return "invalid boolean value: \(str)"
         }
     }
 

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -257,6 +257,31 @@ class JWTKitTests: XCTestCase {
             XCTAssertEqual(payload.foo, "bar")
         }
     }
+
+    func testBoolClaim() throws {
+        let str = #"{"trueStr":"true","trueBool":true,"falseStr":"false","falseBool":false}"#
+        var data = str.data(using: .utf8)!
+        let decoded = try! JSONDecoder().decode(BoolPayload.self, from: data)
+
+        XCTAssertTrue(decoded.trueStr.value)
+        XCTAssertTrue(decoded.trueBool.value)
+        XCTAssertFalse(decoded.falseBool.value)
+        XCTAssertFalse(decoded.falseStr.value)
+
+        data = #"{"bad":"Not boolean"}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(BoolPayload.self, from: data))
+    }
+}
+
+struct BoolPayload: Decodable {
+    var trueStr: BoolClaim
+    var trueBool: BoolClaim
+    var falseStr: BoolClaim
+    var falseBool: BoolClaim
+}
+
+struct BadBoolPayload: Decodable {
+    var bad: BoolClaim
 }
 
 struct TestPayload: JWTPayload, Equatable {


### PR DESCRIPTION
BoolClaim wasn't properly handling "true" and "false" as strings.