### PR TITLE
Add Swift Crypto as a dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "jwt-kit",
     platforms: [
-        .macOS(.v10_14)
+        .macOS(.v10_15)
     ],
     products: [
         .library(name: "JWTKit", targets: ["JWTKit"]),
@@ -12,10 +12,12 @@ let package = Package(
         .library(name: "CJWTKitBoringSSL", type: .static, targets: ["CJWTKitBoringSSL"]),
         MANGLE_END */
     ],
-    dependencies: [ ],
+    dependencies: [
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
+    ],
     targets: [
         .target(name: "CJWTKitBoringSSL"),
-        .target(name: "JWTKit", dependencies: ["CJWTKitBoringSSL"]),
+        .target(name: "JWTKit", dependencies: ["CJWTKitBoringSSL", "Crypto"]),
         .testTarget(name: "JWTKitTests", dependencies: ["JWTKit"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         MANGLE_END */
     ],
     dependencies: [
-    .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
     ],
     targets: [
         .target(name: "CJWTKitBoringSSL"),


### PR DESCRIPTION
This PR simply adds Swift Crypto as a dependency and bumps the minimum macOS version to 10.15.

We want to do this now in preparation of migrating what we can over to Swift Crypto and before the API is stable and we can't release any breaking changes