### PR TITLE
Swift Crypto HMAC integration

### DIFF
--- a/Sources/JWTKit/Signing/HMAC/HMACSigner.swift
+++ b/Sources/JWTKit/Signing/HMAC/HMACSigner.swift
@@ -9,6 +9,6 @@ internal struct HMACSigner<SHA_TYPE>: JWTAlgorithm where SHA_TYPE: HashFunction 
         where Plaintext: DataProtocol
     {
         let authentication = Crypto.HMAC<SHA_TYPE>.authenticationCode(for: plaintext, using: self.key)
-        return Data(authentication).copyBytes()
+        return Array(authentication)
     }
 }

--- a/Sources/JWTKit/Signing/HMAC/HMACSigner.swift
+++ b/Sources/JWTKit/Signing/HMAC/HMACSigner.swift
@@ -1,35 +1,14 @@
-import CJWTKitBoringSSL
+import Crypto
+import Foundation
 
-internal struct HMACSigner: JWTAlgorithm {
-    let key: [UInt8]
-    let algorithm: OpaquePointer
+internal struct HMACSigner<SHA_TYPE>: JWTAlgorithm where SHA_TYPE: HashFunction {
+    let key: SymmetricKey
     let name: String
 
     func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8]
         where Plaintext: DataProtocol
     {
-        let context = CJWTKitBoringSSL_HMAC_CTX_new()
-        defer { CJWTKitBoringSSL_HMAC_CTX_free(context) }
-
-        guard self.key.withUnsafeBytes({
-            return CJWTKitBoringSSL_HMAC_Init_ex(context, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count, self.algorithm, nil)
-        }) == 1 else {
-            throw JWTError.signingAlgorithmFailure(HMACError.initializationFailure)
-        }
-
-        guard plaintext.copyBytes().withUnsafeBytes({
-            return CJWTKitBoringSSL_HMAC_Update(context, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), $0.count)
-        }) == 1 else {
-            throw JWTError.signingAlgorithmFailure(HMACError.updateFailure)
-        }
-        var hash = [UInt8](repeating: 0, count: Int(EVP_MAX_MD_SIZE))
-        var count: UInt32 = 0
-
-        guard hash.withUnsafeMutableBytes({
-            return CJWTKitBoringSSL_HMAC_Final(context, $0.baseAddress?.assumingMemoryBound(to: UInt8.self), &count)
-        }) == 1 else {
-            throw JWTError.signingAlgorithmFailure(HMACError.finalizationFailure)
-        }
-        return .init(hash[0..<Int(count)])
+        let authentication = Crypto.HMAC<SHA_TYPE>.authenticationCode(for: plaintext, using: self.key)
+        return Data(authentication).copyBytes()
     }
 }

--- a/Sources/JWTKit/Signing/HMAC/HMACSigner.swift
+++ b/Sources/JWTKit/Signing/HMAC/HMACSigner.swift
@@ -1,14 +1,14 @@
 import Crypto
 import Foundation
 
-internal struct HMACSigner<SHA_TYPE>: JWTAlgorithm where SHA_TYPE: HashFunction {
+internal struct HMACSigner<SHAType>: JWTAlgorithm where SHAType: HashFunction {
     let key: SymmetricKey
     let name: String
 
     func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8]
         where Plaintext: DataProtocol
     {
-        let authentication = Crypto.HMAC<SHA_TYPE>.authenticationCode(for: plaintext, using: self.key)
+        let authentication = Crypto.HMAC<SHAType>.authenticationCode(for: plaintext, using: self.key)
         return Array(authentication)
     }
 }

--- a/Sources/JWTKit/Signing/HMAC/JWTSigner+HMAC.swift
+++ b/Sources/JWTKit/Signing/HMAC/JWTSigner+HMAC.swift
@@ -1,33 +1,30 @@
-import CJWTKitBoringSSL
+import Crypto
 
 extension JWTSigner {
-    public static func hs256<Key>(key: Key) -> JWTSigner
-        where Key: DataProtocol
-    {
-        return .init(algorithm: HMACSigner(
-            key: key.copyBytes(),
-            algorithm: CJWTKitBoringSSL_EVP_sha256(),
-            name: "HS256"
-        ))
+    public static func hs256(key: SymmetricKey) -> JWTSigner {
+        return .init(algorithm: HMACSigner<SHA256>(key: key, name: "HS256"))
+    }
+    
+    public static func hs256(key: [UInt8]) -> JWTSigner {
+        let symmetricKey = SymmetricKey(data: key)
+        return JWTSigner.hs256(key: symmetricKey)
     }
 
-    public static func hs384<Key>(key: Key) -> JWTSigner
-        where Key: DataProtocol
-    {
-        return .init(algorithm: HMACSigner(
-            key: key.copyBytes(),
-            algorithm: CJWTKitBoringSSL_EVP_sha384(),
-            name: "HS384"
-        ))
+    public static func hs384(key: SymmetricKey) -> JWTSigner {
+        return .init(algorithm: HMACSigner<SHA384>(key: key, name: "HS384"))
     }
 
-    public static func hs512<Key>(key: Key) -> JWTSigner
-        where Key: DataProtocol
-    {
-        return .init(algorithm: HMACSigner(
-            key: key.copyBytes(),
-            algorithm: CJWTKitBoringSSL_EVP_sha512(),
-            name: "HS512"
-        ))
+    public static func hs384(key: [UInt8]) -> JWTSigner {
+        let symmetricKey = SymmetricKey(data: key)
+        return JWTSigner.hs384(key: symmetricKey)
+    }
+
+    public static func hs512(key: SymmetricKey) -> JWTSigner {
+        return .init(algorithm: HMACSigner<SHA512>(key: key, name: "HS512"))
+    }
+
+    public static func hs512(key: [UInt8]) -> JWTSigner {
+        let symmetricKey = SymmetricKey(data: key)
+        return JWTSigner.hs512(key: symmetricKey)
     }
 }


### PR DESCRIPTION
Migrate the JWT HMAC functionality to sit on top of Swift Crypto instead of calling directly to BoringSSL.