### PR TITLE
Support of Microsoft's OpenId Connect platform

### DIFF
--- a/Sources/JWTKit/Keys/JWK.swift
+++ b/Sources/JWTKit/Keys/JWK.swift
@@ -26,28 +26,24 @@ public struct JWK: Decodable {
     public var keyType: KeyType
     
     /// Supported `alg` algorithms
-    public enum Algorithm: Decodable {
+    public enum Algorithm: String, Decodable {
         /// RSA with SHA256
-        case rs256
+        case rs256 = "RS256"
         /// RSA with SHA384
-        case rs384
+        case rs384 = "RS384"
         /// RSA with SHA512
-        case rs512
+        case rs512 = "RS512"
         
         /// Decodes from a lowercased string.
         public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
-            let value = try container.decode(String.self).lowercased()
-            switch value {
-            case "rs256":
-                self = .rs256
-            case "rs384":
-                self = .rs384
-            case "rs512":
-                self = .rs512
-            default:
+            let value = try container.decode(String.self).uppercased()
+            
+            guard let algorithm = Algorithm.init(rawValue: value) else {
                 throw JWTError.invalidJWK
             }
+            
+            self = algorithm
         }
     }
     

--- a/Sources/JWTKit/MicrosoftIdentityToken.swift
+++ b/Sources/JWTKit/MicrosoftIdentityToken.swift
@@ -1,0 +1,120 @@
+/// - See Also:
+/// [Retrieve the User’s Information from Microsoft Servers](https://docs.microsoft.com/pl-pl/azure/active-directory/develop/id-tokens)
+public struct MicrosoftIdentityToken: JWTPayload {
+    enum CodingKeys: String, CodingKey {
+        case nonce, email, name, roles
+        case audience = "aud"
+        case issuer = "iss"
+        case issuedAt = "iat"
+        case identityProvider = "idp"
+        case notBefore = "nbf"
+        case expires = "exp"
+        case codeHash = "c_hash"
+        case accessTokenHash = "at_hash"
+        case preferredUsername = "preferred_username"
+        case objectId = "oid"
+        case subject = "sub"
+        case tenantId = "tid"
+        case uniqueName = "unique_name"
+        case version = "ver"
+    }
+
+    /// Identifies the intended recipient of the token. In id_tokens, the audience is your app's Application ID, assigned to your app
+    /// in the Azure portal. Your app should validate this value, and reject the token if the value does not match.
+    public let audience: AudienceClaim
+    
+    /// Identifies the security token service (STS) that constructs and returns the token, and the Azure AD tenant in which the user
+    /// was authenticated. If the token was issued by the v2.0 endpoint, the URI will end in /v2.0. The GUID that indicates that the
+    /// user is a consumer user from a Microsoft account is 9188040d-6c67-4c5b-b112-36a304b66dad. Your app should use the
+    /// GUID portion of the claim to restrict the set of tenants that can sign in to the app, if applicable.
+    public let issuer: IssuerClaim
+
+    /// "Issued At" indicates when the authentication for this token occurred.
+    public let issuedAt: IssuedAtClaim
+    
+    /// Records the identity provider that authenticated the subject of the token. This value is identical to the value of the Issuer claim
+    /// unless the user account not in the same tenant as the issuer - guests, for instance. If the claim isn't present, it means that the
+    /// value of iss can be used instead. For personal accounts being used in an organizational context (for instance, a personal account
+    /// invited to an Azure AD tenant), the idp claim may be 'live.com' or an STS URI containing the Microsoft account
+    /// tenant 9188040d-6c67-4c5b-b112-36a304b66dad.
+    public let identityProvider: String?
+    
+    /// The "nbf" (not before) claim identifies the time before which the JWT MUST NOT be accepted for processing.
+    public let notBefore: NotBeforeClaim
+    
+    /// The "exp" (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for
+    /// processing. It's important to note that a resource may reject the token before this time as well - if, for example,
+    /// a change in authentication is required or a token revocation has been detected.
+    public let expires: ExpirationClaim
+    
+    /// The code hash is included in ID tokens only when the ID token is issued with an OAuth 2.0 authorization code.
+    /// It can be used to validate the authenticity of an authorization code. For details about performing this validation,
+    /// see the [OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html).
+    public let codeHash: String?
+    
+    /// The access token hash is included in ID tokens only when the ID token is issued with an OAuth 2.0 access token.
+    /// It can be used to validate the authenticity of an access token. For details about performing this validation,
+    /// see the [OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html).
+    public let accessTokenHash: String?
+    
+    /// The primary username that represents the user. It could be an email address, phone number, or a generic username
+    /// without a specified format. Its value is mutable and might change over time. Since it is mutable, this value must not be
+    /// used to make authorization decisions. The profile scope is required to receive this claim.
+    public let preferredUsername: String?
+    
+    /// The email claim is present by default for guest accounts that have an email address. Your app can request the email
+    /// claim for managed users (those from the same tenant as the resource) using the email optional claim. On the v2.0 endpoint,
+    /// your app can also request the email OpenID Connect scope - you don't need to request both the optional claim and the scope
+    /// to get the claim. The email claim only supports addressable mail from the user's profile information.
+    public let email: String?
+    
+    /// The name claim provides a human-readable value that identifies the subject of the token. The value isn't guaranteed
+    /// to be unique, it is mutable, and it's designed to be used only for display purposes. The profile scope is required to receive this claim.
+    public let name: String?
+    
+    /// The nonce matches the parameter included in the original /authorize request to the IDP. If it does not match,
+    /// your application should reject the token.
+    public let nonce: String?
+    
+    /// The immutable identifier for an object in the Microsoft identity system, in this case, a user account. This ID uniquely identifies
+    /// the user across applications - two different applications signing in the same user will receive the same value in the oid claim.
+    /// The Microsoft Graph will return this ID as the id property for a given user account. Because the oid allows multiple apps to
+    /// correlate users, the profile scope is required to receive this claim. Note that if a single user exists in multiple tenants, the user
+    /// will contain a different object ID in each tenant - they're considered different accounts, even though the user logs into each
+    /// account with the same credentials. The oid claim is a GUID and cannot be reused.
+    public let objectId: String
+    
+    /// The set of roles that were assigned to the user who is logging in.
+    public let roles: [String]?
+    
+    /// The principal about which the token asserts information, such as the user of an app. This value is immutable and cannot
+    /// be reassigned or reused. The subject is a pairwise identifier - it is unique to a particular application ID. If a single user signs
+    /// into two different apps using two different client IDs, those apps will receive two different values for the subject claim.
+    /// This may or may not be wanted depending on your architecture and privacy requirements.
+    public let subject: SubjectClaim
+    
+    /// A GUID that represents the Azure AD tenant that the user is from. For work and school accounts, the GUID is the
+    /// immutable tenant ID of the organization that the user belongs to. For personal accounts, the value is
+    /// 9188040d-6c67-4c5b-b112-36a304b66dad. The profile scope is required to receive this claim.
+    public let tenantId: String?
+    
+    /// Provides a human readable value that identifies the subject of the token. This value is unique at any given point in time
+    ///  but as emails and other identifiers can be reused, this value can reappear on other accounts, and should therefore be
+    ///  used only for display purposes. Only issued in v1.0 id_tokens.
+    public let uniqueName: String?
+    
+    /// Indicates the version of the id_token.
+    public let version: String?
+
+    public func verify(using signer: JWTSigner) throws {
+        guard let tenantId = self.tenantId else {
+            throw JWTError.claimVerificationFailure(name: "tid", reason: "Token must contain tenant Id")
+        }
+        
+        guard self.issuer.value == "https://login.microsoftonline.com/\(tenantId)/v2.0" else {
+            throw JWTError.claimVerificationFailure(name: "iss", reason: "Token not provided by Apple")
+        }
+
+        try self.expires.verifyNotExpired()
+    }
+}

--- a/Sources/JWTKit/Signing/JWTSigner+JWK.swift
+++ b/Sources/JWTKit/Signing/JWTSigner+JWK.swift
@@ -3,62 +3,58 @@ import Foundation
 extension JWTSigners {
     /// Adds a `JWKS` (JSON Web Key Set) to this signers collection
     /// by first decoding the JSON string.
-    public func use(jwksJSON json: String, defaultAlgorithm: JWK.Algorithm? = nil) throws {
+    public func use(jwksJSON json: String) throws {
         let jwks = try JSONDecoder().decode(JWKS.self, from: Data(json.utf8))
-        try self.use(jwks: jwks, defaultAlgorithm: defaultAlgorithm)
+        try self.use(jwks: jwks)
     }
     
     /// Adds a `JWKS` (JSON Web Key Set) to this signers collection.
-    public func use(jwks: JWKS, defaultAlgorithm: JWK.Algorithm? = nil) throws {
-        try jwks.keys.forEach { try self.use(jwk: $0, defaultAlgorithm: defaultAlgorithm) }
+    public func use(jwks: JWKS) throws {
+        try jwks.keys.forEach { try self.use(jwk: $0) }
     }
     
     /// Adds a `JWK` (JSON Web Key) to this signers collection.
-    public func use(jwk: JWK, defaultAlgorithm: JWK.Algorithm? = nil) throws {
+    public func use(jwk: JWK) throws {
         guard let kid = jwk.keyIdentifier else {
             throw JWTError.invalidJWK
         }
-        try self.use(.jwk(jwk, defaultAlgorithm: defaultAlgorithm), kid: kid)
+        
+        if jwk.algorithm == nil {
+            try self.use(rsaKey: RSAKey.jwk(jwk), kid: kid)
+        } else {
+            try self.use(.jwk(jwk), kid: kid)
+        }
     }
 }
 
 extension JWTSigner {
     /// Creates a JWT sign from the supplied JWK json string.
-    public static func jwk(json: String, defaultAlgorithm: JWK.Algorithm? = nil) throws -> JWTSigner {
+    public static func jwk(json: String) throws -> JWTSigner {
         let jwk = try JSONDecoder().decode(JWK.self, from: Data(json.utf8))
-        return try self.jwk(jwk, defaultAlgorithm: defaultAlgorithm)
+        return try self.jwk(jwk)
     }
     
     /// Creates a JWT signer with the supplied JWK
-    public static func jwk(_ key: JWK, defaultAlgorithm: JWK.Algorithm? = nil) throws -> JWTSigner {
+    public static func jwk(_ key: JWK) throws -> JWTSigner {
         switch key.keyType {
         case .rsa:
-            guard let modulus = key.modulus else {
-                throw JWTError.invalidJWK
-            }
-            guard let exponent = key.exponent else {
-                throw JWTError.invalidJWK
-            }
-            guard let algorithm = (key.algorithm ?? defaultAlgorithm) else {
+            guard let algorithm = key.algorithm else {
                 throw JWTError.invalidJWK
             }
             
-            guard let rsaKey = RSAKey(
-                modulus: modulus,
-                exponent: exponent,
-                privateExponent: key.privateExponent
-            ) else {
-                throw JWTError.invalidJWK
-            }
-            
-            switch algorithm {
-            case .rs256:
-                return JWTSigner.rs256(key: rsaKey)
-            case .rs384:
-                return JWTSigner.rs384(key: rsaKey)
-            case .rs512:
-                return JWTSigner.rs512(key: rsaKey)
-            }
+            let rsaKey = try RSAKey.jwk(key)
+            return .rsaKey(rsaKey, algorithm: algorithm)
+        }
+    }
+    
+    public static func rsaKey(_ rsaKey: RSAKey, algorithm: JWK.Algorithm) -> JWTSigner {
+        switch algorithm {
+        case .rs256:
+            return JWTSigner.rs256(key: rsaKey)
+        case .rs384:
+            return JWTSigner.rs384(key: rsaKey)
+        case .rs512:
+            return JWTSigner.rs512(key: rsaKey)
         }
     }
 }

--- a/Sources/JWTKit/Signing/JWTSigners.swift
+++ b/Sources/JWTKit/Signing/JWTSigners.swift
@@ -6,12 +6,16 @@ import struct Foundation.Data
 public final class JWTSigners {
     /// Internal storage.
     private var storage: [JWKIdentifier: JWTSigner]
+    
+    /// Internal storage for RSA keys for JWK with unknown algorithm.
+    private var rsaKeysStorage: [JWKIdentifier: RSAKey]
 
     private var `default`: JWTSigner?
 
     /// Create a new `JWTSigners`.
     public init() {
         self.storage = [:]
+        self.rsaKeysStorage = [:]
     }
 
     /// Adds a new signer.
@@ -27,18 +31,40 @@ public final class JWTSigners {
             self.default = signer
         }
     }
+    
+    /// Adds a new RSA keys connected with JWK.
+    public func use(rsaKey: RSAKey, kid: JWKIdentifier)
+    {
+        self.rsaKeysStorage[kid] = rsaKey
+    }
 
-    /// Gets a signer for the supplied `kid`, if one exists.
-    public func get(kid: JWKIdentifier? = nil) -> JWTSigner? {
+    /// Gets a signer for the supplied `kid` and `algorithm`, if one exists.
+    public func get(kid: JWKIdentifier? = nil, algorithm: String? = nil) -> JWTSigner? {
         if let kid = kid {
-            return self.storage[kid]
+            if let jwtSigner = self.storage[kid] {
+                return jwtSigner
+            }
+            
+            guard let rsaKey = self.rsaKeysStorage[kid] else {
+                return nil
+            }
+            
+            guard let algorithm = algorithm else {
+                return nil
+            }
+            
+            guard let alg = JWK.Algorithm(rawValue: algorithm) else {
+                return nil
+            }
+            
+            return .rsaKey(rsaKey, algorithm: alg)
         } else {
             return self.default
         }
     }
 
-    public func require(kid: JWKIdentifier? = nil) throws -> JWTSigner {
-        guard let signer = self.get(kid: kid) else {
+    public func require(kid: JWKIdentifier? = nil, algorithm: String? = nil) throws -> JWTSigner {
+        guard let signer = self.get(kid: kid, algorithm: algorithm) else {
             if let kid = kid {
                 throw JWTError.unknownKID(kid)
             } else {
@@ -84,7 +110,8 @@ public final class JWTSigners {
     {
         let parser = try JWTParser(token: token)
         let header = try parser.header()
-        return try self.require(kid: header.kid).verify(parser: parser)
+        
+        return try self.require(kid: header.kid, algorithm: header.alg).verify(parser: parser)
     }
 
     public func sign<Payload>(

--- a/Sources/JWTKit/Signing/RSA/RSAKey+JWK.swift
+++ b/Sources/JWTKit/Signing/RSA/RSAKey+JWK.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension RSAKey {
+    /// Creates a RSA key for supplied JWK.
+    public static func jwk(json: String) throws -> RSAKey {
+        let jwk = try JSONDecoder().decode(JWK.self, from: Data(json.utf8))
+        return try self.jwk(jwk)
+    }
+    
+    /// Creates a RSA key for supplied JWK.
+    public static func jwk(_ key: JWK) throws -> RSAKey {
+        switch key.keyType {
+        case .rsa:
+            guard let modulus = key.modulus else {
+                throw JWTError.invalidJWK
+            }
+            guard let exponent = key.exponent else {
+                throw JWTError.invalidJWK
+            }
+            
+            guard let rsaKey = RSAKey(
+                modulus: modulus,
+                exponent: exponent,
+                privateExponent: key.privateExponent
+            ) else {
+                throw JWTError.invalidJWK
+            }
+            
+            return rsaKey
+        }
+    }
+}


### PR DESCRIPTION
Support for [Microsoft OpenId Connect platform](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols). 

Unfortunatelly Microsoft's [JWK](https://login.microsoftonline.com/common/discovery/keys) file doesn't contain "alg" (Algorithm) parameter. According to [RFC7517](https://tools.ietf.org/html/rfc7517#page-8) that parameter is optional. Probably the best way is to get correct algorithm from JWT token header, but that change requires much more work. 

<s>Pull request besides MicrosoftIdentityToken (JWTPayload) adds also "defaultAlgorithm" parameters to some of methods in JWTSigners class.</s>