### PR TITLE
Add typ, cty fields in the JWT header

### DIFF
--- a/Sources/JWTKit/JWTSerializer.swift
+++ b/Sources/JWTKit/JWTSerializer.swift
@@ -5,7 +5,8 @@ struct JWTSerializer {
         _ payload: Payload,
         using signer: JWTSigner,
         typ: String = "JWT",
-        kid: JWKIdentifier? = nil
+        kid: JWKIdentifier? = nil,
+        cty: String? = nil
     ) throws -> String
         where Payload: JWTPayload
     {
@@ -16,6 +17,7 @@ struct JWTSerializer {
         var header = JWTHeader()
         header.kid = kid
         header.typ = typ
+        header.cty = cty
         header.alg = signer.algorithm.name
 
         let headerData = try jsonEncoder.encode(header)

--- a/Sources/JWTKit/Signing/JWTSigner.swift
+++ b/Sources/JWTKit/Signing/JWTSigner.swift
@@ -7,11 +7,12 @@ public final class JWTSigner {
     }
 
     public func sign<Payload>(
-        _ payload: Payload
+        _ payload: Payload,
+        cty: String? = nil
     ) throws -> String
         where Payload: JWTPayload
     {
-        try JWTSerializer().sign(payload, using: self, kid: nil)
+        try JWTSerializer().sign(payload, using: self, kid: nil, cty: cty)
     }
 
     public func unverified<Payload>(

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -40,7 +40,7 @@ class JWTKitTests: XCTestCase {
         let exp = ExpirationClaim(value: Date(timeIntervalSince1970: 2_000_000_000))
         let jwt = try JWTSigner.hs256(key: "secret".bytes)
             .sign(ExpirationPayload(exp: exp))
-        XCTAssertEqual(jwt, "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjIwMDAwMDAwMDB9.4W6egHvMSp9bBiGUnE7WhVfXazOfg-ADcjvIYILgyPU")
+        XCTAssertEqual(jwt, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIwMDAwMDAwMDB9.JgCO_GqUQnbS0z2hCxJLE9Tpt5SMoZObHBxzGBWuTYQ")
     }
 
     func testSigners() throws {


### PR DESCRIPTION
Adds `typ` and `cty` fields to the JWT header (#25, fixes #5).

- Add `typ` header as parameter making "JWT" the default. 

- Allow setting `cty` during JWT signing.

```swift
let signer = JWTSigner.hs256(key: keyData)`
let token = try signer.sign(payload, cty: "twilio-fpa;v=1")
```


