### PR TITLE
Add RSAKey support for x509 certificate

### DIFF
--- a/Sources/JWTKit/RSA/RSAKey.swift
+++ b/Sources/JWTKit/RSA/RSAKey.swift
@@ -2,10 +2,38 @@ import CJWTKitBoringSSL
 import struct Foundation.Data
 
 public final class RSAKey: OpenSSLKey {
+    /// Creates RSAKey from public key pem file.
+    ///
+    /// Public key pem files look like:
+    ///
+    ///     -----BEGIN PUBLIC KEY-----
+    ///     MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0cOtPjzABybjzm3fCg1aCYwnx
+    ///     ...
+    ///     aX4rbSL49Z3dAQn8vQIDAQAB
+    ///     -----END PUBLIC KEY-----
+    ///
+    /// This key can only be used to verify JWTs.
+    ///
+    /// - parameters:
+    ///     - pem: Contents of pem file.
     public static func `public`(pem string: String) throws -> RSAKey {
         try .public(pem: [UInt8](string.utf8))
     }
 
+    /// Creates RSAKey from public key pem file.
+    ///
+    /// Public key pem files look like:
+    ///
+    ///     -----BEGIN PUBLIC KEY-----
+    ///     MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0cOtPjzABybjzm3fCg1aCYwnx
+    ///     ...
+    ///     aX4rbSL49Z3dAQn8vQIDAQAB
+    ///     -----END PUBLIC KEY-----
+    ///
+    /// This key can only be used to verify JWTs.
+    ///
+    /// - parameters:
+    ///     - pem: Contents of pem file.
     public static func `public`<Data>(pem data: Data) throws -> RSAKey
         where Data: DataProtocol
     {
@@ -20,10 +48,86 @@ public final class RSAKey: OpenSSLKey {
         return self.init(c, .public)
     }
 
+    /// Creates RSAKey from public certificate pem file.
+    ///
+    /// Certificate pem files look like:
+    ///
+    ///     -----BEGIN CERTIFICATE-----
+    ///     MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0cOtPjzABybjzm3fCg1aCYwnx
+    ///     ...
+    ///     aX4rbSL49Z3dAQn8vQIDAQAB
+    ///     -----END CERTIFICATE-----
+    ///
+    /// This key can only be used to verify JWTs.
+    ///
+    /// - parameters:
+    ///     - pem: Contents of pem file.
+    public static func certificate(pem string: String) throws -> RSAKey {
+        try self.certificate(pem: [UInt8](string.utf8))
+    }
+
+    /// Creates RSAKey from public certificate pem file.
+    ///
+    /// Certificate pem files look like:
+    ///
+    ///     -----BEGIN CERTIFICATE-----
+    ///     MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0cOtPjzABybjzm3fCg1aCYwnx
+    ///     ...
+    ///     aX4rbSL49Z3dAQn8vQIDAQAB
+    ///     -----END CERTIFICATE-----
+    ///
+    /// This key can only be used to verify JWTs.
+    ///
+    /// - parameters:
+    ///     - pem: Contents of pem file.
+    public static func certificate<Data>(pem data: Data) throws -> RSAKey
+        where Data: DataProtocol
+    {
+        let x509 = try self.load(pem: data) { bio in
+            CJWTKitBoringSSL_PEM_read_bio_X509(bio, nil, nil, nil)
+        }
+        defer { CJWTKitBoringSSL_X509_free(x509) }
+        let pkey = CJWTKitBoringSSL_X509_get_pubkey(x509)
+        defer { CJWTKitBoringSSL_EVP_PKEY_free(pkey) }
+
+        guard let c = CJWTKitBoringSSL_EVP_PKEY_get1_RSA(pkey) else {
+            throw JWTError.signingAlgorithmFailure(RSAError.keyInitializationFailure)
+        }
+        return self.init(c, .public)
+    }
+
+    /// Creates RSAKey from private key pem file.
+    ///
+    /// Private key pem files look like:
+    ///
+    ///     -----BEGIN PRIVATE KEY-----
+    ///     MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0cOtPjzABybjzm3fCg1aCYwnx
+    ///     ...
+    ///     aX4rbSL49Z3dAQn8vQIDAQAB
+    ///     -----END PRIVATE KEY-----
+    ///
+    /// This key can be used to verify and sign JWTs.
+    ///
+    /// - parameters:
+    ///     - pem: Contents of pem file.
     public static func `private`(pem string: String) throws -> RSAKey {
         try .private(pem: [UInt8](string.utf8))
     }
 
+    /// Creates RSAKey from private key pem file.
+    ///
+    /// Private key pem files look like:
+    ///
+    ///     -----BEGIN PRIVATE KEY-----
+    ///     MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0cOtPjzABybjzm3fCg1aCYwnx
+    ///     ...
+    ///     aX4rbSL49Z3dAQn8vQIDAQAB
+    ///     -----END PRIVATE KEY-----
+    ///
+    /// This key can be used to verify and sign JWTs.
+    ///
+    /// - parameters:
+    ///     - pem: Contents of pem file.
     public static func `private`<Data>(pem data: Data) throws -> RSAKey
         where Data: DataProtocol
     {

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -474,6 +474,23 @@ class JWTKitTests: XCTestCase {
         let signers = JWTSigners()
         try signers.use(jwksJSON: microsoftJWKS)
     }
+
+    func testFoo() throws {
+        let test = TestPayload(
+            sub: "vapor",
+            name: "foo",
+            admin: true,
+            exp: .init(value: .distantFuture)
+        )
+        let jwt = try JWTSigner.rs256(
+            key: .private(pem: rsa2PrivateKey)
+        ).sign(test)
+
+        let payload = try JWTSigner.rs256(
+            key: .certificate(pem: rsa2Cert)
+        ).verify(jwt, as: TestPayload.self)
+        XCTAssertEqual(payload, test)
+    }
 }
 
 struct AudiencePayload: Codable {
@@ -609,6 +626,34 @@ PmjXpbCkecAWLj/CcDWEcuTZkYDiSG0zgglbbbhcV0vJQDWSv60tnlA3cjSYutAv
 7FPo5Cq8FkvrdDzeacwRSxYuIq1LtYnd6I30qNaNthntjvbqyMmBulJ1mzLI+Xg/
 aX4rbSL49Z3dAQn8vQIDAQAB
 -----END PUBLIC KEY-----
+"""
+
+let rsa2PrivateKey = """
+-----BEGIN PRIVATE KEY-----
+MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAtgeOpWeiRIq0Blbc
+qq4P7sKnyDmj1mpQq7OyRKZM0qbwyyMM5Nisf5Y+RSDM7JDwqMeLspGo5znLBzN5
+L14JIQIDAQABAkBlMWRSfX9O3VDhKU65L9S5pcsCW1DCdQ3tthMHaO/SNn4jhmbf
+MamrK4TWctjuau+CwUtQz/kS/fjveYBSVklVAiEA2r1fExLdTwo1pRzCqvUhq7MO
+4wu1dPvv8mJZZvGxQGMCIQDVCVsmeiN+s9erwd95wUZKb4zBkT6MQC0r1fGQBnEN
+qwIgBBT6nDmC5cG0BJPH0jbm3PRnd7c1OKym6qgJMRGblC8CICh9Zr2haS2jsNIM
+PxU9DscG/JGtsV2mtO8n8omVL9eRAiEA1ccs/gJCMAwJ/jeA8tZwOF3GEb/9tGow
+RR8+JsDsJY8=
+-----END PRIVATE KEY-----
+"""
+
+let rsa2Cert = """
+-----BEGIN CERTIFICATE-----
+MIIBzjCCAXgCCQDnzO/FvcHZbjANBgkqhkiG9w0BAQsFADBuMQswCQYDVQQGEwJV
+UzELMAkGA1UECAwCTlkxDDAKBgNVBAcMA05ZQzEOMAwGA1UECgwFVmFwb3IxFDAS
+BgNVBAMMC3ZhcG9yLmNvZGVzMR4wHAYJKoZIhvcNAQkBFg9qd3RAdmFwb3IuY29k
+ZXMwHhcNMjAwNzMxMjMyOTQ5WhcNMjEwNzMxMjMyOTQ5WjBuMQswCQYDVQQGEwJV
+UzELMAkGA1UECAwCTlkxDDAKBgNVBAcMA05ZQzEOMAwGA1UECgwFVmFwb3IxFDAS
+BgNVBAMMC3ZhcG9yLmNvZGVzMR4wHAYJKoZIhvcNAQkBFg9qd3RAdmFwb3IuY29k
+ZXMwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAtgeOpWeiRIq0Blbcqq4P7sKnyDmj
+1mpQq7OyRKZM0qbwyyMM5Nisf5Y+RSDM7JDwqMeLspGo5znLBzN5L14JIQIDAQAB
+MA0GCSqGSIb3DQEBCwUAA0EAQyBP1X40S4joTg1ov4eK0aKNlRLbWftEorGh5jCc
+F3IAwlztc7uFj589k/M+xO4TGdrEVlMyiVdC5/B0MLa8LQ==
+-----END CERTIFICATE-----
 """
 
 extension String {


### PR DESCRIPTION
Adds support for initializing `RSAKey` from X.509 certificate pem files (#42).

```swift
// Create signer from X.509 certificate
let signer = try JWTSigner.rs256(key: .certificate(pem: ...))
```