### PR TITLE
Unify Vendor Claim Verification Failure Message

### DIFF
--- a/Sources/JWTKit/Vendor/GoogleIdentityToken.swift
+++ b/Sources/JWTKit/Vendor/GoogleIdentityToken.swift
@@ -100,7 +100,7 @@ public struct GoogleIdentityToken: JWTPayload {
 
     public func verify(using signer: JWTSigner) throws {
         guard ["accounts.google.com", "https://accounts.google.com"].contains(self.issuer.value) else {
-            throw JWTError.claimVerificationFailure(name: "iss", reason: "Claim wasn't issued by Google")
+            throw JWTError.claimVerificationFailure(name: "iss", reason: "Token not provided by Google")
         }
 
         guard self.subject.value.count <= 255 else {

--- a/Sources/JWTKit/Vendor/MicrosoftIdentitiyToken.swift
+++ b/Sources/JWTKit/Vendor/MicrosoftIdentitiyToken.swift
@@ -112,7 +112,7 @@ public struct MicrosoftIdentityToken: JWTPayload {
         }
 
         guard self.issuer.value == "https://login.microsoftonline.com/\(tenantId)/v2.0" else {
-            throw JWTError.claimVerificationFailure(name: "iss", reason: "Token not provided by Apple")
+            throw JWTError.claimVerificationFailure(name: "iss", reason: "Token not provided by Microsoft")
         }
 
         try self.expires.verifyNotExpired()


### PR DESCRIPTION
Unify messaging for issuer `JWTError.claimVerificationFailure` for Apple, Microsoft and Google to read `Token not provided by INSERT_VENDOR`. Also fixes a typo in the `Microsoft` error. (#49)