### PR TITLE
Fix typo in license

### DIFF
--- a/scripts/build-asm.py
+++ b/scripts/build-asm.py
@@ -12,7 +12,7 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-# This was substantially adapted from SwiftCyrpto's vendor-boringssl.sh script.
+# This was substantially adapted from SwiftCrypto's vendor-boringssl.sh script.
 # The license for the original work is reproduced below. See NOTICES.txt for
 # more.
 #

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -11,7 +11,7 @@
 ## SPDX-License-Identifier: MIT
 ##
 ##===----------------------------------------------------------------------===##
-# This was substantially adapted from SwiftCyrpto's vendor-boringssl.sh script.
+# This was substantially adapted from SwiftCrypto's vendor-boringssl.sh script.
 # The license for the original work is reproduced below. See NOTICES.txt for
 # more.
 #


### PR DESCRIPTION
Fix reference to original project SwiftCrypto in build scripts.