### PR TITLE
Fix typo for `JWTError.signatureVerificationFailed` case

### DIFF
--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -4,7 +4,7 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
     case claimVerificationFailure(name: String, reason: String)
     case signingAlgorithmFailure(Error)
     case malformedToken
-    case signatureVerifictionFailed
+    case signatureVerificationFailed
     case missingKIDHeader
     case unknownKID(JWKIdentifier)
     case invalidJWK
@@ -19,7 +19,7 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
             return "signing algorithm error: \(error)"
         case .malformedToken:
             return "malformed JWT"
-        case .signatureVerifictionFailed:
+        case .signatureVerificationFailed:
             return "signature verification failed"
         case .missingKIDHeader:
             return "missing kid field in header"

--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -31,7 +31,7 @@ struct JWTParser {
 
     func verify(using signer: JWTSigner) throws {
         guard try signer.algorithm.verify(self.signature, signs: self.message) else {
-            throw JWTError.signatureVerifictionFailed
+            throw JWTError.signatureVerificationFailed
         }
     }
 

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -332,7 +332,7 @@ class JWTKitTests: XCTestCase {
             _ = try publicSigner.verify(corruptedToken, as: JWTioPayload.self)
         } catch let error as JWTError {
             switch error {
-            case .signatureVerifictionFailed:
+            case .signatureVerificationFailed:
                 // pass
                 XCTAssert(true)
             default:


### PR DESCRIPTION
Just something I noticed while using the library. Unless there's another way to do, this would be a breaking change, so if semver is to be strictly followed it'd involve a major version bump. Up to you :)