### PR TITLE
FIX Issue #46

### DIFF
--- a/Sources/JWTKit/Utilities/BigNumber.swift
+++ b/Sources/JWTKit/Utilities/BigNumber.swift
@@ -16,8 +16,8 @@ class BigNumber {
         CJWTKitBoringSSL_BN_free(self.c);
     }
 
-    public static func convert(_ bnBase64: String) -> BigNumber? {
-        guard let data = Data(base64Encoded: bnBase64) else {
+    public static func convert(_ bnBase64Url: String) -> BigNumber? {
+        guard let data = bnBase64Url.data(using: .utf8)?.base64URLDecodedBytes() else {
             return nil
         }
 

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -290,6 +290,44 @@ class JWTKitTests: XCTestCase {
         let foo = try signers.verify(jwt, as: Foo.self)
         XCTAssertEqual(foo.bar, 42)
     }
+
+    func testVerifyingECDSAKeyUsingJWKBase64URL() throws {
+        struct Foo: JWTPayload {
+            var bar: Int
+            func verify(using signer: JWTSigner) throws { }
+        }
+                
+        // ecdsa key
+        let x = "BRSikX2rNlAhJD5mw1KCEAIKK3_yttL_zvo9IXvD59o"
+        let y = "LtIcnj_SNmpl9NlW7gmW9Mkj3n6qvpWRqPMxBS0Asw8"
+        
+        // let privateKey = "k+1LAHQRSSMcyaouYK0YOzRbUKj6ISnvihO2XdLQZHQgMt9BkuCT0+539FSHmJxg"
+
+        // sign jwt
+        // let privateSigner = JWTSigner.es384(key: try ECDSAKey(parameters: .init(x: x, y: y), curve: .p384, privateKey: privateKey))
+        
+        // let jwt = try privateSigner.sign(Foo(bar: 42), kid: "vapor")
+
+        // verify using jwks without alg
+        let jwksString = """
+        {
+            "keys": [
+                {
+                    "kty": "EC",
+                    "use": "sig",
+                    "kid": "vapor",
+                    "x": "\(x)",
+                    "y": "\(y)"
+                 }
+            ]
+        }
+        """
+
+        let signers = JWTSigners()
+        try signers.use(jwksJSON: jwksString)
+        let signer = signers.get(kid: "vapor", alg: "ES256")
+        XCTAssertNotNil(signer)
+    }
     
     func testJWTioExample() throws {
         let token = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA"


### PR DESCRIPTION
Hi from [RFC7517](https://datatracker.ietf.org/doc/html/rfc7517)

an jwk representing an ecdsa key is represented with the parameters x and y in base64url-encoded form.

The issue was caused by the fact that the parameters were converted using `Data(base64Encoded: String)` which doesn't decode an base64url string
