### PR TITLE
Add experimental watchOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
         .macOS(.v10_15),
         .iOS(.v13),
         .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(name: "JWTKit", targets: ["JWTKit"]),


### PR DESCRIPTION
Adds experimental watchOS support by providing a watchOS platform to match the minimum version of the dependencies so it will compile
