### PR TITLE
Add `JWTSigner.unsecuredNone`

### DIFF
--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -8,7 +8,8 @@ struct JWTParser {
     init<Token>(token: Token) throws
         where Token: DataProtocol
     {
-        let tokenParts = token.copyBytes().split(separator: .period)
+        let tokenParts = token.copyBytes()
+            .split(separator: .period, omittingEmptySubsequences: false)
         guard tokenParts.count == 3 else {
             throw JWTError.malformedToken
         }

--- a/Sources/JWTKit/None/JWTSigner+UnsecuredNone.swift
+++ b/Sources/JWTKit/None/JWTSigner+UnsecuredNone.swift
@@ -1,0 +1,3 @@
+extension JWTSigner {
+    public static let unsecuredNone: JWTSigner = .init(algorithm: UnsecuredNoneSigner())
+}

--- a/Sources/JWTKit/None/UnsecuredNoneSigner.swift
+++ b/Sources/JWTKit/None/UnsecuredNoneSigner.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+internal struct UnsecuredNoneSigner: JWTAlgorithm {
+    var name: String {
+        "none"
+    }
+    
+    func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8]
+        where Plaintext: DataProtocol
+    {
+        []
+    }
+    
+    func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool
+        where Signature: DataProtocol, Plaintext: DataProtocol
+    {
+        signature.isEmpty
+    }
+}

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -159,6 +159,7 @@ class JWTKitTests: XCTestCase {
         let signer = JWTSigner.unsecuredNone
         let token = try signer.sign(payload)
         try XCTAssertEqual(signer.verify(token.bytes, as: TestPayload.self), payload)
+        XCTAssertTrue(token.hasSuffix("."))
     }
 
     func testRSA() throws {

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -150,6 +150,8 @@ class JWTKitTests: XCTestCase {
     }
     
     func testUnsecuredNone() throws {
+        let data =
+            "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJleHAiOjIwMDAwMDAwMDAsImFkbWluIjpmYWxzZSwibmFtZSI6IkZvbyIsInN1YiI6InZhcG9yIn0."
         let payload = TestPayload(
             sub: "vapor",
             name: "Foo",
@@ -159,6 +161,7 @@ class JWTKitTests: XCTestCase {
         let signer = JWTSigner.unsecuredNone
         let token = try signer.sign(payload)
         try XCTAssertEqual(signer.verify(token.bytes, as: TestPayload.self), payload)
+        try XCTAssertEqual(signer.verify(data.bytes, as: TestPayload.self), payload)
         XCTAssertTrue(token.hasSuffix("."))
     }
 

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -148,6 +148,18 @@ class JWTKitTests: XCTestCase {
         let payload = try signers.verify(data, as: TestPayload.self)
         XCTAssertEqual(payload.name, "John Doe")
     }
+    
+    func testUnsecuredNone() throws {
+        let payload = TestPayload(
+            sub: "vapor",
+            name: "Foo",
+            admin: false,
+            exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+        )
+        let signer = JWTSigner.unsecuredNone
+        let token = try signer.sign(payload)
+        try XCTAssertEqual(signer.verify(token.bytes, as: TestPayload.self), payload)
+    }
 
     func testRSA() throws {
         let privateSigner = try JWTSigner.rs256(key: .private(pem: rsaPrivateKey.bytes))


### PR DESCRIPTION
This PR adds support for the "none" algorithm described in [Section 6 of RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519#section-6).