### PR TITLE
Add support for Octet Key Pairs with the EdDSA algorithm using the ED25519 curve

### DIFF
--- a/Sources/JWTKit/ECDSA/ECDSAKey.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKey.swift
@@ -5,6 +5,7 @@ public final class ECDSAKey: OpenSSLKey {
         case p256 = "P-256"
         case p384 = "P-384"
         case p521 = "P-521"
+		case ed25519 = "Ed25519"
 
         var cName: Int32 {
             switch self {
@@ -14,6 +15,8 @@ public final class ECDSAKey: OpenSSLKey {
                 return NID_secp384r1
             case .p521:
                 return NID_secp521r1
+			case .ed25519:
+				return NID_ED25519
             }
         }
       
@@ -25,6 +28,8 @@ public final class ECDSAKey: OpenSSLKey {
                 self = .p384
             case NID_secp521r1:
                 self = .p521
+			case NID_ED25519:
+				self = .ed25519
             default:
                 return nil
             }

--- a/Sources/JWTKit/ECDSA/ECDSAKey.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKey.swift
@@ -2,10 +2,15 @@
 
 public final class ECDSAKey: OpenSSLKey {
     
-    @available(*, deprecated, renamed: "JWK.Curve")
-    public typealias Curve = JWK.Curve
+    public enum Curve: String, Codable {
+        case p256 = "P-256"
+        case p384 = "P-384"
+        case p521 = "P-521"
+        case ed25519 = "Ed25519"
+        case ed448 = "Ed448"
+    }
     
-    public static func generate(curve: JWK.Curve = .p521) throws -> ECDSAKey {
+    public static func generate(curve: Curve = .p521) throws -> ECDSAKey {
         guard let c = CJWTKitBoringSSL_EC_KEY_new_by_curve_name(curve.cName) else {
             throw JWTError.signingAlgorithmFailure(ECDSAError.newKeyByCurveFailure)
         }
@@ -47,7 +52,7 @@ public final class ECDSAKey: OpenSSLKey {
         self.c = c
     }
     
-    public convenience init(parameters: Parameters, curve: JWK.Curve = .p521, privateKey: String? = nil) throws {
+    public convenience init(parameters: Parameters, curve: Curve = .p521, privateKey: String? = nil) throws {
         guard let c = CJWTKitBoringSSL_EC_KEY_new_by_curve_name(curve.cName) else {
             throw JWTError.signingAlgorithmFailure(ECDSAError.newKeyByCurveFailure)
         }
@@ -79,10 +84,10 @@ public final class ECDSAKey: OpenSSLKey {
         CJWTKitBoringSSL_EC_KEY_free(self.c)
     }
   
-    public var curve: JWK.Curve? {
+    public var curve: Curve? {
         let group: OpaquePointer = CJWTKitBoringSSL_EC_KEY_get0_group(self.c)
         let cName = CJWTKitBoringSSL_EC_GROUP_get_curve_name(group)
-        return JWK.Curve(cName: cName)
+        return Curve(cName: cName)
     }
     
     public var parameters: Parameters? {
@@ -104,7 +109,7 @@ public final class ECDSAKey: OpenSSLKey {
     }
 }
 
-extension JWK.Curve {
+extension ECDSAKey.Curve {
     var cName: Int32 {
         switch self {
         case .p256:

--- a/Sources/JWTKit/ECDSA/ECDSAKey.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKey.swift
@@ -1,6 +1,9 @@
 @_implementationOnly import CJWTKitBoringSSL
 
 public final class ECDSAKey: OpenSSLKey {
+	
+	@available(*, deprecated, renamed: "JWK.Curve")
+	public typealias Curve = JWK.Curve
     
 	public static func generate(curve: JWK.Curve = .p521) throws -> ECDSAKey {
         guard let c = CJWTKitBoringSSL_EC_KEY_new_by_curve_name(curve.cName) else {

--- a/Sources/JWTKit/ECDSA/ECDSAKey.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKey.swift
@@ -5,7 +5,7 @@ public final class ECDSAKey: OpenSSLKey {
 	@available(*, deprecated, renamed: "JWK.Curve")
 	public typealias Curve = JWK.Curve
     
-	public static func generate(curve: JWK.Curve = .p521) throws -> ECDSAKey {
+    public static func generate(curve: JWK.Curve = .p521) throws -> ECDSAKey {
         guard let c = CJWTKitBoringSSL_EC_KEY_new_by_curve_name(curve.cName) else {
             throw JWTError.signingAlgorithmFailure(ECDSAError.newKeyByCurveFailure)
         }
@@ -47,7 +47,7 @@ public final class ECDSAKey: OpenSSLKey {
         self.c = c
     }
     
-	public convenience init(parameters: Parameters, curve: JWK.Curve = .p521, privateKey: String? = nil) throws {
+    public convenience init(parameters: Parameters, curve: JWK.Curve = .p521, privateKey: String? = nil) throws {
         guard let c = CJWTKitBoringSSL_EC_KEY_new_by_curve_name(curve.cName) else {
             throw JWTError.signingAlgorithmFailure(ECDSAError.newKeyByCurveFailure)
         }
@@ -120,20 +120,20 @@ extension JWK.Curve {
 		}
 	}
   
-	init?(cName: Int32) {
-		switch cName {
-		case NID_X9_62_prime256v1:
-			self = .p256
-		case NID_secp384r1:
-			self = .p384
-		case NID_secp521r1:
-			self = .p521
-		case NID_ED25519:
-			self = .ed25519
-		case NID_ED448:
-			self = .ed448
-		default:
-			return nil
-		}
-	}
+    init?(cName: Int32) {
+        switch cName {
+        case NID_X9_62_prime256v1:
+            self = .p256
+        case NID_secp384r1:
+            self = .p384
+        case NID_secp521r1:
+            self = .p521
+        case NID_ED25519:
+            self = .ed25519
+        case NID_ED448:
+            self = .ed448
+        default:
+            return nil
+        }
+    }
 }

--- a/Sources/JWTKit/ECDSA/ECDSAKey.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKey.swift
@@ -1,42 +1,8 @@
 @_implementationOnly import CJWTKitBoringSSL
 
 public final class ECDSAKey: OpenSSLKey {
-    public enum Curve: String, Codable {
-        case p256 = "P-256"
-        case p384 = "P-384"
-        case p521 = "P-521"
-		case ed25519 = "Ed25519"
-
-        var cName: Int32 {
-            switch self {
-            case .p256:
-                return NID_X9_62_prime256v1
-            case .p384:
-                return NID_secp384r1
-            case .p521:
-                return NID_secp521r1
-			case .ed25519:
-				return NID_ED25519
-            }
-        }
-      
-        init?(cName: Int32) {
-            switch cName {
-            case NID_X9_62_prime256v1:
-                self = .p256
-            case NID_secp384r1:
-                self = .p384
-            case NID_secp521r1:
-                self = .p521
-			case NID_ED25519:
-				self = .ed25519
-            default:
-                return nil
-            }
-        }
-    }
     
-    public static func generate(curve: Curve = .p521) throws -> ECDSAKey {
+	public static func generate(curve: JWK.Curve = .p521) throws -> ECDSAKey {
         guard let c = CJWTKitBoringSSL_EC_KEY_new_by_curve_name(curve.cName) else {
             throw JWTError.signingAlgorithmFailure(ECDSAError.newKeyByCurveFailure)
         }
@@ -78,7 +44,7 @@ public final class ECDSAKey: OpenSSLKey {
         self.c = c
     }
     
-    public convenience init(parameters: Parameters, curve: Curve = .p521, privateKey: String? = nil) throws {
+	public convenience init(parameters: Parameters, curve: JWK.Curve = .p521, privateKey: String? = nil) throws {
         guard let c = CJWTKitBoringSSL_EC_KEY_new_by_curve_name(curve.cName) else {
             throw JWTError.signingAlgorithmFailure(ECDSAError.newKeyByCurveFailure)
         }
@@ -110,10 +76,10 @@ public final class ECDSAKey: OpenSSLKey {
         CJWTKitBoringSSL_EC_KEY_free(self.c)
     }
   
-    public var curve: Curve? {
+	public var curve: JWK.Curve? {
         let group: OpaquePointer = CJWTKitBoringSSL_EC_KEY_get0_group(self.c)
         let cName = CJWTKitBoringSSL_EC_GROUP_get_curve_name(group)
-        return Curve(cName: cName)
+        return JWK.Curve(cName: cName)
     }
     
     public var parameters: Parameters? {
@@ -133,4 +99,38 @@ public final class ECDSAKey: OpenSSLKey {
         public let x: String
         public let y: String
     }
+}
+
+extension JWK.Curve {
+	var cName: Int32 {
+		switch self {
+		case .p256:
+			return NID_X9_62_prime256v1
+		case .p384:
+			return NID_secp384r1
+		case .p521:
+			return NID_secp521r1
+		case .ed25519:
+			return NID_ED25519
+		case .ed448:
+			return NID_ED448
+		}
+	}
+  
+	init?(cName: Int32) {
+		switch cName {
+		case NID_X9_62_prime256v1:
+			self = .p256
+		case NID_secp384r1:
+			self = .p384
+		case NID_secp521r1:
+			self = .p521
+		case NID_ED25519:
+			self = .ed25519
+		case NID_ED448:
+			self = .ed448
+		default:
+			return nil
+		}
+	}
 }

--- a/Sources/JWTKit/ECDSA/ECDSAKey.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKey.swift
@@ -1,9 +1,9 @@
 @_implementationOnly import CJWTKitBoringSSL
 
 public final class ECDSAKey: OpenSSLKey {
-	
-	@available(*, deprecated, renamed: "JWK.Curve")
-	public typealias Curve = JWK.Curve
+    
+    @available(*, deprecated, renamed: "JWK.Curve")
+    public typealias Curve = JWK.Curve
     
     public static func generate(curve: JWK.Curve = .p521) throws -> ECDSAKey {
         guard let c = CJWTKitBoringSSL_EC_KEY_new_by_curve_name(curve.cName) else {
@@ -79,7 +79,7 @@ public final class ECDSAKey: OpenSSLKey {
         CJWTKitBoringSSL_EC_KEY_free(self.c)
     }
   
-	public var curve: JWK.Curve? {
+    public var curve: JWK.Curve? {
         let group: OpaquePointer = CJWTKitBoringSSL_EC_KEY_get0_group(self.c)
         let cName = CJWTKitBoringSSL_EC_GROUP_get_curve_name(group)
         return JWK.Curve(cName: cName)
@@ -105,20 +105,20 @@ public final class ECDSAKey: OpenSSLKey {
 }
 
 extension JWK.Curve {
-	var cName: Int32 {
-		switch self {
-		case .p256:
-			return NID_X9_62_prime256v1
-		case .p384:
-			return NID_secp384r1
-		case .p521:
-			return NID_secp521r1
-		case .ed25519:
-			return NID_ED25519
-		case .ed448:
-			return NID_ED448
-		}
-	}
+    var cName: Int32 {
+        switch self {
+        case .p256:
+            return NID_X9_62_prime256v1
+        case .p384:
+            return NID_secp384r1
+        case .p521:
+            return NID_secp521r1
+        case .ed25519:
+            return NID_ED25519
+        case .ed448:
+            return NID_ED448
+        }
+    }
   
     init?(cName: Int32) {
         switch cName {

--- a/Sources/JWTKit/EdDSA/EdDSAError.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAError.swift
@@ -1,6 +1,6 @@
-internal enum EdDSAError: Error {	
-	case publicAndPrivateKeyMissing
-	case privateKeyMissing
-	case publicKeyMissing
-	case curveNotSupported(JWK.Curve)
+internal enum EdDSAError: Error {
+    case publicAndPrivateKeyMissing
+    case privateKeyMissing
+    case publicKeyMissing
+    case curveNotSupported(JWK.Curve)
 }

--- a/Sources/JWTKit/EdDSA/EdDSAError.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAError.swift
@@ -1,3 +1,5 @@
 internal enum EdDSAError: Error {	
 	case privateKeyMissing
+	case curveNotSupported(JWK.Curve)
+	case publicKeyMissing
 }

--- a/Sources/JWTKit/EdDSA/EdDSAError.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAError.swift
@@ -1,5 +1,6 @@
 internal enum EdDSAError: Error {	
+	case publicAndPrivateKeyMissing
 	case privateKeyMissing
-	case curveNotSupported(JWK.Curve)
 	case publicKeyMissing
+	case curveNotSupported(JWK.Curve)
 }

--- a/Sources/JWTKit/EdDSA/EdDSAError.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAError.swift
@@ -1,0 +1,3 @@
+internal enum EdDSAError: Error {	
+	case generateKeyFailure
+}

--- a/Sources/JWTKit/EdDSA/EdDSAError.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAError.swift
@@ -1,3 +1,3 @@
 internal enum EdDSAError: Error {	
-	case generateKeyFailure
+	case privateKeyMissing
 }

--- a/Sources/JWTKit/EdDSA/EdDSAError.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAError.swift
@@ -2,5 +2,4 @@ internal enum EdDSAError: Error {
     case publicAndPrivateKeyMissing
     case privateKeyMissing
     case publicKeyMissing
-    case curveNotSupported(JWK.Curve)
 }

--- a/Sources/JWTKit/EdDSA/EdDSAKey.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAKey.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public struct EdDSAKey {
+	
+	let publicKey: Data
+	let privateKey: Data?
+	let curve: JWK.Curve
+	
+	public init?(x: String, d: String? = nil, curve: JWK.Curve = .ed25519) {
+		guard let x = Data(base64Encoded: x.base64UrlEncodedToBase64()) else {
+			return nil
+		}
+		
+		self.init(
+			publicKey: x,
+			privateKey: d.flatMap { Data(base64Encoded: $0.base64UrlEncodedToBase64()) },
+			curve: curve
+		)
+	}
+	
+	public init(publicKey: Data, privateKey: Data? = nil, curve: JWK.Curve = .ed25519) {
+		self.publicKey = publicKey
+		self.privateKey = privateKey
+		self.curve = curve
+	}
+}
+
+extension String {
+	func base64UrlEncodedToBase64() -> String {
+		var base64 = replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+		if base64.count % 4 != 0 {
+			base64.append(
+				String(repeating: "=", count: 4 - base64.count % 4)
+			)
+		}
+		return base64
+	}
+}

--- a/Sources/JWTKit/EdDSA/EdDSAKey.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAKey.swift
@@ -6,19 +6,24 @@ public struct EdDSAKey {
 	let privateKey: Data?
 	let curve: JWK.Curve
 	
-	public init?(x: String, d: String? = nil, curve: JWK.Curve = .ed25519) {
+	public init(x: String, d: String? = nil, curve: JWK.Curve = .ed25519) throws {
+		
 		guard let x = Data(base64Encoded: x.base64UrlEncodedToBase64()) else {
-			return nil
+			throw EdDSAError.publicKeyMissing
 		}
 		
-		self.init(
+		try self.init(
 			publicKey: x,
 			privateKey: d.flatMap { Data(base64Encoded: $0.base64UrlEncodedToBase64()) },
 			curve: curve
 		)
 	}
 	
-	public init(publicKey: Data, privateKey: Data? = nil, curve: JWK.Curve = .ed25519) {
+	public init(publicKey: Data, privateKey: Data? = nil, curve: JWK.Curve = .ed25519) throws {
+		guard curve == .ed25519 else {
+			throw EdDSAError.curveNotSupported(curve)
+		}
+				
 		self.publicKey = publicKey
 		self.privateKey = privateKey
 		self.curve = curve

--- a/Sources/JWTKit/EdDSA/EdDSAKey.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAKey.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Crypto
 
 public struct EdDSAKey {
 	
@@ -27,6 +28,19 @@ public struct EdDSAKey {
 		self.publicKey = publicKey
 		self.privateKey = privateKey
 		self.curve = curve
+	}
+	
+	public static func generate(curve: JWK.Curve = .ed25519) throws -> EdDSAKey {
+		guard curve == .ed25519 else {
+			throw EdDSAError.curveNotSupported(curve)
+		}
+		
+		let key = Curve25519.Signing.PrivateKey()
+		return try .init(
+			publicKey: key.publicKey.rawRepresentation,
+			privateKey: key.rawRepresentation,
+			curve: curve
+		)
 	}
 }
 

--- a/Sources/JWTKit/EdDSA/EdDSAKey.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAKey.swift
@@ -3,6 +3,10 @@ import Crypto
 
 public struct EdDSAKey {
             
+    public enum Curve: String, Codable {
+        case ed25519 = "Ed25519"
+    }
+    
     let keyPair: OctetKeyPair
     var publicKey: Data? {
         keyPair.publicKey
@@ -10,9 +14,9 @@ public struct EdDSAKey {
     var privateKey: Data? {
         keyPair.privateKey
     }
-    let curve: JWK.Curve
+    let curve: Curve
     
-    public init(x: String?, d: String? = nil, curve: JWK.Curve = .ed25519) throws {
+    public init(x: String?, d: String? = nil, curve: Curve = .ed25519) throws {
         try self.init(
             publicKey: x.flatMap { $0.data(using: .utf8) }.map { Data($0.base64URLDecodedBytes()) },
             privateKey: d.flatMap { $0.data(using: .utf8) }.map { Data($0.base64URLDecodedBytes()) },
@@ -20,32 +24,28 @@ public struct EdDSAKey {
         )
     }
     
-    public init(publicKey: Data? = nil, privateKey: Data? = nil, curve: JWK.Curve = .ed25519) throws {
+    public init(publicKey: Data? = nil, privateKey: Data? = nil, curve: Curve = .ed25519) throws {
         try self.init(
             keyPair: try .init(publicKey: publicKey, privateKey: privateKey),
             curve: curve
         )
     }
     
-    init(keyPair: OctetKeyPair, curve: JWK.Curve = .ed25519) throws {
-        guard curve == .ed25519 else {
-            throw JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(curve))
-        }
+    init(keyPair: OctetKeyPair, curve: Curve = .ed25519) throws {
         self.keyPair = keyPair
         self.curve = curve
     }
     
-    public static func generate(curve: JWK.Curve = .ed25519) throws -> EdDSAKey {
-        guard curve == .ed25519 else {
-            throw JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(curve))
+    public static func generate(curve: Curve = .ed25519) throws -> EdDSAKey {
+        switch curve {
+        case .ed25519:            
+            let key = Curve25519.Signing.PrivateKey()
+            return try .init(
+                publicKey: key.publicKey.rawRepresentation,
+                privateKey: key.rawRepresentation,
+                curve: curve
+            )
         }
-        
-        let key = Curve25519.Signing.PrivateKey()
-        return try .init(
-            publicKey: key.publicKey.rawRepresentation,
-            privateKey: key.rawRepresentation,
-            curve: curve
-        )
     }
 }
 

--- a/Sources/JWTKit/EdDSA/EdDSAKey.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAKey.swift
@@ -2,31 +2,36 @@ import Foundation
 import Crypto
 
 public struct EdDSAKey {
-	
-	let publicKey: Data
-	let privateKey: Data?
+			
+	let keyPair: OctetKeyPair
+	var publicKey: Data? {
+		keyPair.publicKey
+	}
+	var privateKey: Data? {
+		keyPair.privateKey
+	}
 	let curve: JWK.Curve
 	
-	public init(x: String, d: String? = nil, curve: JWK.Curve = .ed25519) throws {
-				
-		guard let x = x.data(using: .utf8) else {
-			throw JWTError.signingAlgorithmFailure(EdDSAError.publicKeyMissing)
-		}
-		
+	public init(x: String?, d: String? = nil, curve: JWK.Curve = .ed25519) throws {
 		try self.init(
-			publicKey: Data(x.base64URLDecodedBytes()),
+			publicKey: x.flatMap { $0.data(using: .utf8) }.map { Data($0.base64URLDecodedBytes()) },
 			privateKey: d.flatMap { $0.data(using: .utf8) }.map { Data($0.base64URLDecodedBytes()) },
 			curve: curve
 		)
 	}
 	
-	public init(publicKey: Data, privateKey: Data? = nil, curve: JWK.Curve = .ed25519) throws {
+	public init(publicKey: Data? = nil, privateKey: Data? = nil, curve: JWK.Curve = .ed25519) throws {
+		try self.init(
+			keyPair: try .init(publicKey: publicKey, privateKey: privateKey),
+			curve: curve
+		)
+	}
+	
+	init(keyPair: OctetKeyPair, curve: JWK.Curve = .ed25519) throws {
 		guard curve == .ed25519 else {
 			throw JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(curve))
 		}
-				
-		self.publicKey = publicKey
-		self.privateKey = privateKey
+		self.keyPair = keyPair
 		self.curve = curve
 	}
 	

--- a/Sources/JWTKit/EdDSA/EdDSAKey.swift
+++ b/Sources/JWTKit/EdDSA/EdDSAKey.swift
@@ -2,50 +2,50 @@ import Foundation
 import Crypto
 
 public struct EdDSAKey {
-			
-	let keyPair: OctetKeyPair
-	var publicKey: Data? {
-		keyPair.publicKey
-	}
-	var privateKey: Data? {
-		keyPair.privateKey
-	}
-	let curve: JWK.Curve
-	
-	public init(x: String?, d: String? = nil, curve: JWK.Curve = .ed25519) throws {
-		try self.init(
-			publicKey: x.flatMap { $0.data(using: .utf8) }.map { Data($0.base64URLDecodedBytes()) },
-			privateKey: d.flatMap { $0.data(using: .utf8) }.map { Data($0.base64URLDecodedBytes()) },
-			curve: curve
-		)
-	}
-	
-	public init(publicKey: Data? = nil, privateKey: Data? = nil, curve: JWK.Curve = .ed25519) throws {
-		try self.init(
-			keyPair: try .init(publicKey: publicKey, privateKey: privateKey),
-			curve: curve
-		)
-	}
-	
-	init(keyPair: OctetKeyPair, curve: JWK.Curve = .ed25519) throws {
-		guard curve == .ed25519 else {
-			throw JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(curve))
-		}
-		self.keyPair = keyPair
-		self.curve = curve
-	}
-	
-	public static func generate(curve: JWK.Curve = .ed25519) throws -> EdDSAKey {
-		guard curve == .ed25519 else {
-			throw JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(curve))
-		}
-		
-		let key = Curve25519.Signing.PrivateKey()
-		return try .init(
-			publicKey: key.publicKey.rawRepresentation,
-			privateKey: key.rawRepresentation,
-			curve: curve
-		)
-	}
+            
+    let keyPair: OctetKeyPair
+    var publicKey: Data? {
+        keyPair.publicKey
+    }
+    var privateKey: Data? {
+        keyPair.privateKey
+    }
+    let curve: JWK.Curve
+    
+    public init(x: String?, d: String? = nil, curve: JWK.Curve = .ed25519) throws {
+        try self.init(
+            publicKey: x.flatMap { $0.data(using: .utf8) }.map { Data($0.base64URLDecodedBytes()) },
+            privateKey: d.flatMap { $0.data(using: .utf8) }.map { Data($0.base64URLDecodedBytes()) },
+            curve: curve
+        )
+    }
+    
+    public init(publicKey: Data? = nil, privateKey: Data? = nil, curve: JWK.Curve = .ed25519) throws {
+        try self.init(
+            keyPair: try .init(publicKey: publicKey, privateKey: privateKey),
+            curve: curve
+        )
+    }
+    
+    init(keyPair: OctetKeyPair, curve: JWK.Curve = .ed25519) throws {
+        guard curve == .ed25519 else {
+            throw JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(curve))
+        }
+        self.keyPair = keyPair
+        self.curve = curve
+    }
+    
+    public static func generate(curve: JWK.Curve = .ed25519) throws -> EdDSAKey {
+        guard curve == .ed25519 else {
+            throw JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(curve))
+        }
+        
+        let key = Curve25519.Signing.PrivateKey()
+        return try .init(
+            publicKey: key.publicKey.rawRepresentation,
+            privateKey: key.rawRepresentation,
+            curve: curve
+        )
+    }
 }
 

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -6,7 +6,7 @@ internal struct EdDSASigner: JWTAlgorithm {
 	
 	func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
 		guard let privateKey = key.privateKey else {
-			throw EdDSAError.generateKeyFailure
+			throw EdDSAError.privateKeyMissing
 		}
 		
 		return try Curve25519.Signing.PrivateKey(

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -7,11 +7,11 @@ internal struct EdDSASigner: JWTAlgorithm {
 	func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
 		
 		guard key.curve == .ed25519 else {
-			throw EdDSAError.curveNotSupported(key.curve)
+			throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
 		}
 		
 		guard let privateKey = key.privateKey else {
-			throw EdDSAError.privateKeyMissing
+			throw  JWTError.signingAlgorithmFailure(EdDSAError.privateKeyMissing)
 		}
 		
 		return try Curve25519.Signing.PrivateKey(
@@ -24,7 +24,7 @@ internal struct EdDSASigner: JWTAlgorithm {
 	func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
 		
 		guard key.curve == .ed25519 else {
-			throw EdDSAError.curveNotSupported(key.curve)
+			throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
 		}
 		
 		return try Curve25519.Signing.PublicKey(

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -1,41 +1,41 @@
 import Crypto
 
 internal struct EdDSASigner: JWTAlgorithm {
-	let key: EdDSAKey
-	let name = "EdDSA"
-	
-	func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
-		
-		guard key.curve == .ed25519 else {
-			throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
-		}
-		
-		guard let privateKey = key.privateKey else {
-			throw  JWTError.signingAlgorithmFailure(EdDSAError.privateKeyMissing)
-		}
-		
-		return try Curve25519.Signing.PrivateKey(
-			rawRepresentation: privateKey
-		).signature(
-			for: plaintext
-		).copyBytes()
-	}
-	
-	func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
-		
-		guard key.curve == .ed25519 else {
-			throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
-		}
-		
-		guard let publicKey = key.publicKey else {
-			throw  JWTError.signingAlgorithmFailure(EdDSAError.publicKeyMissing)
-		}
-		
-		return try Curve25519.Signing.PublicKey(
-			rawRepresentation: publicKey
-		).isValidSignature(
-			signature,
-			for: plaintext
-		)
-	}
+    let key: EdDSAKey
+    let name = "EdDSA"
+    
+    func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
+        
+        guard key.curve == .ed25519 else {
+            throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
+        }
+        
+        guard let privateKey = key.privateKey else {
+            throw  JWTError.signingAlgorithmFailure(EdDSAError.privateKeyMissing)
+        }
+        
+        return try Curve25519.Signing.PrivateKey(
+            rawRepresentation: privateKey
+        ).signature(
+            for: plaintext
+        ).copyBytes()
+    }
+    
+    func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
+        
+        guard key.curve == .ed25519 else {
+            throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
+        }
+        
+        guard let publicKey = key.publicKey else {
+            throw  JWTError.signingAlgorithmFailure(EdDSAError.publicKeyMissing)
+        }
+        
+        return try Curve25519.Signing.PublicKey(
+            rawRepresentation: publicKey
+        ).isValidSignature(
+            signature,
+            for: plaintext
+        )
+    }
 }

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -27,8 +27,12 @@ internal struct EdDSASigner: JWTAlgorithm {
 			throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
 		}
 		
+		guard let publicKey = key.publicKey else {
+			throw  JWTError.signingAlgorithmFailure(EdDSAError.publicKeyMissing)
+		}
+		
 		return try Curve25519.Signing.PublicKey(
-			rawRepresentation: key.publicKey
+			rawRepresentation: publicKey
 		).isValidSignature(
 			signature,
 			for: plaintext

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -5,6 +5,11 @@ internal struct EdDSASigner: JWTAlgorithm {
 	let name = "EdDSA"
 	
 	func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
+		
+		guard key.curve == .ed25519 else {
+			throw EdDSAError.curveNotSupported(key.curve)
+		}
+		
 		guard let privateKey = key.privateKey else {
 			throw EdDSAError.privateKeyMissing
 		}
@@ -18,7 +23,11 @@ internal struct EdDSASigner: JWTAlgorithm {
 	
 	func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
 		
-		try Curve25519.Signing.PublicKey(
+		guard key.curve == .ed25519 else {
+			throw EdDSAError.curveNotSupported(key.curve)
+		}
+		
+		return try Curve25519.Signing.PublicKey(
 			rawRepresentation: key.publicKey
 		).isValidSignature(
 			signature,

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -4,9 +4,7 @@ internal struct EdDSASigner: JWTAlgorithm {
     let key: EdDSAKey
     let name = "EdDSA"
     
-    func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
-        
-        
+    func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {                
         guard let privateKey = key.privateKey else {
             throw  JWTError.signingAlgorithmFailure(EdDSAError.privateKeyMissing)
         }
@@ -22,15 +20,10 @@ internal struct EdDSASigner: JWTAlgorithm {
     }
     
     func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
-        
-        guard let publicKey = key.publicKey else {
-            throw  JWTError.signingAlgorithmFailure(EdDSAError.publicKeyMissing)
-        }
-        
         switch key.curve {
         case .ed25519:
             return try Curve25519.Signing.PublicKey(
-                rawRepresentation: publicKey
+                rawRepresentation: key.publicKey
             ).isValidSignature(
                 signature,
                 for: plaintext

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -6,36 +6,35 @@ internal struct EdDSASigner: JWTAlgorithm {
     
     func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
         
-        guard key.curve == .ed25519 else {
-            throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
-        }
         
         guard let privateKey = key.privateKey else {
             throw  JWTError.signingAlgorithmFailure(EdDSAError.privateKeyMissing)
         }
         
-        return try Curve25519.Signing.PrivateKey(
-            rawRepresentation: privateKey
-        ).signature(
-            for: plaintext
-        ).copyBytes()
+        switch key.curve {
+        case .ed25519:
+            return try Curve25519.Signing.PrivateKey(
+                rawRepresentation: privateKey
+            ).signature(
+                for: plaintext
+            ).copyBytes()
+        }
     }
     
     func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
-        
-        guard key.curve == .ed25519 else {
-            throw  JWTError.signingAlgorithmFailure(EdDSAError.curveNotSupported(key.curve))
-        }
         
         guard let publicKey = key.publicKey else {
             throw  JWTError.signingAlgorithmFailure(EdDSAError.publicKeyMissing)
         }
         
-        return try Curve25519.Signing.PublicKey(
-            rawRepresentation: publicKey
-        ).isValidSignature(
-            signature,
-            for: plaintext
-        )
+        switch key.curve {
+        case .ed25519:
+            return try Curve25519.Signing.PublicKey(
+                rawRepresentation: publicKey
+            ).isValidSignature(
+                signature,
+                for: plaintext
+            )
+        }
     }
 }

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -1,0 +1,25 @@
+import Crypto
+
+internal struct EdDSASigner<D: ContiguousBytes>: JWTAlgorithm {
+	let publicKey: D
+	let privateKey: D
+	let name = "EdDSA"
+	
+	func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
+		try Curve25519.Signing.PrivateKey(
+			rawRepresentation: privateKey
+		).signature(
+			for: plaintext
+		).copyBytes()
+	}
+	
+	func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
+				
+		try Curve25519.Signing.PublicKey(
+			rawRepresentation: publicKey
+		).isValidSignature(
+			signature,
+			for: plaintext
+		)
+	}
+}

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -17,7 +17,7 @@ internal struct EdDSASigner: JWTAlgorithm {
 	}
 	
 	func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
-				
+		
 		try Curve25519.Signing.PublicKey(
 			rawRepresentation: key.publicKey
 		).isValidSignature(

--- a/Sources/JWTKit/EdDSA/EdDSASigner.swift
+++ b/Sources/JWTKit/EdDSA/EdDSASigner.swift
@@ -1,12 +1,11 @@
 import Crypto
 
-internal struct EdDSASigner<D: ContiguousBytes>: JWTAlgorithm {
-	let publicKey: D
-	let privateKey: D?
+internal struct EdDSASigner: JWTAlgorithm {
+	let key: EdDSAKey
 	let name = "EdDSA"
 	
 	func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8] where Plaintext : DataProtocol {
-		guard let privateKey = privateKey else {
+		guard let privateKey = key.privateKey else {
 			throw EdDSAError.generateKeyFailure
 		}
 		
@@ -20,22 +19,10 @@ internal struct EdDSASigner<D: ContiguousBytes>: JWTAlgorithm {
 	func verify<Signature, Plaintext>(_ signature: Signature, signs plaintext: Plaintext) throws -> Bool where Signature : DataProtocol, Plaintext : DataProtocol {
 				
 		try Curve25519.Signing.PublicKey(
-			rawRepresentation: publicKey
+			rawRepresentation: key.publicKey
 		).isValidSignature(
 			signature,
 			for: plaintext
 		)
-	}
-}
-
-extension String {
-	func base64UrlEncodedToBase64() -> String {
-		var base64 = replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
-		if base64.count % 4 != 0 {
-			base64.append(
-				String(repeating: "=", count: 4 - base64.count % 4)
-			)
-		}
-		return base64
 	}
 }

--- a/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
+++ b/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
@@ -2,12 +2,7 @@ import Foundation
 import Crypto
 
 extension JWTSigner {
-	public static func eddsa<D: ContiguousBytes>(publicKey: D, privateKey: D?) -> JWTSigner {
-		.init(
-			algorithm: EdDSASigner(
-				publicKey: publicKey,
-				privateKey: privateKey
-			)
-		)
+	public static func eddsa(_ key: EdDSAKey) -> JWTSigner {
+		.init(algorithm: EdDSASigner(key: key))
 	}
 }

--- a/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
+++ b/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
@@ -2,7 +2,7 @@ import Foundation
 import Crypto
 
 extension JWTSigner {
-	public static func eddsa<D: ContiguousBytes>(publicKey: D, privateKey: D) -> JWTSigner {
+	public static func eddsa<D: ContiguousBytes>(publicKey: D, privateKey: D?) -> JWTSigner {
 		.init(
 			algorithm: EdDSASigner(
 				publicKey: publicKey,

--- a/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
+++ b/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Crypto
+
+extension JWTSigner {
+	public static func eddsa(publicKey: Data, privateKey: Data) -> JWTSigner {
+		.init(
+			algorithm: EdDSASigner(
+				publicKey: publicKey,
+				privateKey: privateKey
+			)
+		)
+	}
+}

--- a/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
+++ b/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
@@ -2,7 +2,7 @@ import Foundation
 import Crypto
 
 extension JWTSigner {
-	public static func eddsa(_ key: EdDSAKey) -> JWTSigner {
-		.init(algorithm: EdDSASigner(key: key))
-	}
+    public static func eddsa(_ key: EdDSAKey) -> JWTSigner {
+        .init(algorithm: EdDSASigner(key: key))
+    }
 }

--- a/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
+++ b/Sources/JWTKit/EdDSA/JWTSigner+EdDSA.swift
@@ -2,7 +2,7 @@ import Foundation
 import Crypto
 
 extension JWTSigner {
-	public static func eddsa(publicKey: Data, privateKey: Data) -> JWTSigner {
+	public static func eddsa<D: ContiguousBytes>(publicKey: D, privateKey: D) -> JWTSigner {
 		.init(
 			algorithm: EdDSASigner(
 				publicKey: publicKey,

--- a/Sources/JWTKit/EdDSA/OctetKeyPair.swift
+++ b/Sources/JWTKit/EdDSA/OctetKeyPair.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+enum OctetKeyPair {
+	case `public`(Data)
+	case `private`(Data)
+	case `publicPrivate`(x: Data, d: Data)
+	
+	init(publicKey: Data?, privateKey: Data?) throws {
+		switch (publicKey, privateKey) {
+			case (.some(let publicKey), .some(let privateKey)):
+				self = .publicPrivate(x: publicKey, d: privateKey)
+				
+			case (.some(let publicKey), .none):
+				self = .public(publicKey)
+				
+			case (.none, .some(let privateKey)):
+				self = .private(privateKey)
+				
+			case (.none, .none):
+				throw EdDSAError.publicAndPrivateKeyMissing
+		}
+	}
+	
+	var publicKey: Data? {
+		switch self {
+			case .private:
+				return nil
+				
+			case .public(let publicKey), .publicPrivate(let publicKey, _):
+				return publicKey
+		}
+	}
+	
+	var privateKey: Data? {
+		switch self {
+			case .public:
+				return nil
+				
+			case .private(let privateKey), .publicPrivate(_, let privateKey):
+				return privateKey
+		}
+	}
+}

--- a/Sources/JWTKit/EdDSA/OctetKeyPair.swift
+++ b/Sources/JWTKit/EdDSA/OctetKeyPair.swift
@@ -1,43 +1,43 @@
 import Foundation
 
 enum OctetKeyPair {
-	case `public`(Data)
-	case `private`(Data)
-	case `publicPrivate`(x: Data, d: Data)
-	
-	init(publicKey: Data?, privateKey: Data?) throws {
-		switch (publicKey, privateKey) {
-			case (.some(let publicKey), .some(let privateKey)):
-				self = .publicPrivate(x: publicKey, d: privateKey)
-				
-			case (.some(let publicKey), .none):
-				self = .public(publicKey)
-				
-			case (.none, .some(let privateKey)):
-				self = .private(privateKey)
-				
-			case (.none, .none):
-				throw EdDSAError.publicAndPrivateKeyMissing
-		}
-	}
-	
-	var publicKey: Data? {
-		switch self {
-			case .private:
-				return nil
-				
-			case .public(let publicKey), .publicPrivate(let publicKey, _):
-				return publicKey
-		}
-	}
-	
-	var privateKey: Data? {
-		switch self {
-			case .public:
-				return nil
-				
-			case .private(let privateKey), .publicPrivate(_, let privateKey):
-				return privateKey
-		}
-	}
+    case `public`(Data)
+    case `private`(Data)
+    case `publicPrivate`(x: Data, d: Data)
+    
+    init(publicKey: Data?, privateKey: Data?) throws {
+        switch (publicKey, privateKey) {
+            case (.some(let publicKey), .some(let privateKey)):
+                self = .publicPrivate(x: publicKey, d: privateKey)
+                
+            case (.some(let publicKey), .none):
+                self = .public(publicKey)
+                
+            case (.none, .some(let privateKey)):
+                self = .private(privateKey)
+                
+            case (.none, .none):
+                throw EdDSAError.publicAndPrivateKeyMissing
+        }
+    }
+    
+    var publicKey: Data? {
+        switch self {
+            case .private:
+                return nil
+                
+            case .public(let publicKey), .publicPrivate(let publicKey, _):
+                return publicKey
+        }
+    }
+    
+    var privateKey: Data? {
+        switch self {
+            case .public:
+                return nil
+                
+            case .private(let privateKey), .publicPrivate(_, let privateKey):
+                return privateKey
+        }
+    }
 }

--- a/Sources/JWTKit/EdDSA/OctetKeyPair.swift
+++ b/Sources/JWTKit/EdDSA/OctetKeyPair.swift
@@ -1,43 +1,32 @@
 import Foundation
 
+// https://www.rfc-editor.org/rfc/rfc8037.html#appendix-A
 enum OctetKeyPair {
-    case `public`(Data)
-    case `private`(Data)
-    case `publicPrivate`(x: Data, d: Data)
+    case `public`(x: Data)
+    case `private`(x: Data, d: Data)
     
-    init(publicKey: Data?, privateKey: Data?) throws {
-        switch (publicKey, privateKey) {
-            case (.some(let publicKey), .some(let privateKey)):
-                self = .publicPrivate(x: publicKey, d: privateKey)
-                
-            case (.some(let publicKey), .none):
-                self = .public(publicKey)
-                
-            case (.none, .some(let privateKey)):
-                self = .private(privateKey)
-                
-            case (.none, .none):
-                throw EdDSAError.publicAndPrivateKeyMissing
-        }
+    init(x: Data, d: Data) throws {
+        self = .`private`(x: x, d: d)
     }
     
-    var publicKey: Data? {
+    init(x: Data) throws {
+        self = .`public`(x: x)
+    }
+    
+    var publicKey: Data {
         switch self {
-            case .private:
-                return nil
-                
-            case .public(let publicKey), .publicPrivate(let publicKey, _):
-                return publicKey
+            case .`public`(let x), .`private`(let x, _):
+                return x
         }
     }
     
     var privateKey: Data? {
         switch self {
-            case .public:
-                return nil
+            case .`private`(_ , let d):
+                return d
                 
-            case .private(let privateKey), .publicPrivate(_, let privateKey):
-                return privateKey
+            case .`public`:
+                return nil
         }
     }
 }

--- a/Sources/JWTKit/JWK/JWK.swift
+++ b/Sources/JWTKit/JWK/JWK.swift
@@ -5,7 +5,7 @@ import class Foundation.JSONDecoder
 ///
 /// Read specification (RFC 7517) https://tools.ietf.org/html/rfc7517.
 public struct JWK: Codable {
-
+    
     public enum Curve: String, Codable {
         case p256 = "P-256"
         case p384 = "P-384"
@@ -104,12 +104,12 @@ public struct JWK: Codable {
         JWK(keyType: .rsa, algorithm: algorithm, keyIdentifier: identifier, n: modulus, e: exponent, d: privateExponent)
     }
     
-    public static func ecdsa(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: JWK.Curve?, privateKey: String? = nil) -> JWK {
-        return JWK(keyType: .ecdsa, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, y: y, curve: curve)
+    public static func ecdsa(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: ECDSAKey.Curve?, privateKey: String? = nil) -> JWK {
+        return JWK(keyType: .ecdsa, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, y: y, curve: curve.flatMap { Curve(rawValue: $0.rawValue) })
     }
     
-    public static func octetKeyPair(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: JWK.Curve?, privateKey: String? = nil) -> JWK {
-        return JWK(keyType: .octetKeyPair, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, curve: curve)
+    public static func octetKeyPair(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: EdDSAKey.Curve?, privateKey: String? = nil) -> JWK {
+        return JWK(keyType: .octetKeyPair, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, curve: curve.flatMap { Curve(rawValue: $0.rawValue) })
     }
     
     private init(

--- a/Sources/JWTKit/JWK/JWK.swift
+++ b/Sources/JWTKit/JWK/JWK.swift
@@ -82,7 +82,7 @@ public struct JWK: Codable {
 
     public var y: String?
     
-    public var curve: JWK.Curve?
+    public var curve: Curve?
         
     private enum CodingKeys: String, CodingKey {
         case keyType = "kty"
@@ -107,6 +107,10 @@ public struct JWK: Codable {
     public static func ecdsa(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: JWK.Curve?, privateKey: String? = nil) -> JWK {
         return JWK(keyType: .ecdsa, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, y: y, curve: curve)
     }
+	
+	public static func octetKeyPair(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: JWK.Curve?, privateKey: String? = nil) -> JWK {
+		return JWK(keyType: .octetKeyPair, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, curve: curve)
+	}
     
     private init(
         keyType: KeyType,
@@ -117,7 +121,7 @@ public struct JWK: Codable {
         d: String? = nil,
         x: String? = nil,
         y: String? = nil,
-        curve: JWK.Curve? = nil
+        curve: Curve? = nil
     ) {
         self.keyType = keyType
         self.algorithm = algorithm

--- a/Sources/JWTKit/JWK/JWK.swift
+++ b/Sources/JWTKit/JWK/JWK.swift
@@ -11,6 +11,8 @@ public struct JWK: Codable {
         case rsa = "RSA"
         /// ECDSA
         case ecdsa = "EC"
+		/// Octet Key Pair
+		case octetKeyPair = "OKP"
     }
      
     /// The `kty` (key type) parameter identifies the cryptographic algorithm
@@ -32,6 +34,8 @@ public struct JWK: Codable {
         case es384 = "ES384"
         /// EC with SHA512
         case es512 = "ES512"
+		/// EdDSA
+		case eddsa = "EdDSA"
     }
      
      /// The `alg` (algorithm) parameter identifies the algorithm intended for

--- a/Sources/JWTKit/JWK/JWK.swift
+++ b/Sources/JWTKit/JWK/JWK.swift
@@ -5,6 +5,15 @@ import class Foundation.JSONDecoder
 ///
 /// Read specification (RFC 7517) https://tools.ietf.org/html/rfc7517.
 public struct JWK: Codable {
+	
+	public enum Curve: String, Codable {
+		case p256 = "P-256"
+		case p384 = "P-384"
+		case p521 = "P-521"
+		case ed25519 = "Ed25519"
+		case ed448 = "Ed448"
+	}
+	
     /// Supported `kty` key types.
     public enum KeyType: String, Codable {
         /// RSA
@@ -73,7 +82,7 @@ public struct JWK: Codable {
 
     public var y: String?
     
-    public var curve: ECDSAKey.Curve?
+    public var curve: JWK.Curve?
         
     private enum CodingKeys: String, CodingKey {
         case keyType = "kty"
@@ -95,7 +104,7 @@ public struct JWK: Codable {
         JWK(keyType: .rsa, algorithm: algorithm, keyIdentifier: identifier, n: modulus, e: exponent, d: privateExponent)
     }
     
-    public static func ecdsa(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: ECDSAKey.Curve?, privateKey: String? = nil) -> JWK {
+    public static func ecdsa(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: JWK.Curve?, privateKey: String? = nil) -> JWK {
         return JWK(keyType: .ecdsa, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, y: y, curve: curve)
     }
     
@@ -108,7 +117,7 @@ public struct JWK: Codable {
         d: String? = nil,
         x: String? = nil,
         y: String? = nil,
-        curve: ECDSAKey.Curve? = nil
+        curve: JWK.Curve? = nil
     ) {
         self.keyType = keyType
         self.algorithm = algorithm

--- a/Sources/JWTKit/JWK/JWK.swift
+++ b/Sources/JWTKit/JWK/JWK.swift
@@ -5,23 +5,23 @@ import class Foundation.JSONDecoder
 ///
 /// Read specification (RFC 7517) https://tools.ietf.org/html/rfc7517.
 public struct JWK: Codable {
-	
-	public enum Curve: String, Codable {
-		case p256 = "P-256"
-		case p384 = "P-384"
-		case p521 = "P-521"
-		case ed25519 = "Ed25519"
-		case ed448 = "Ed448"
-	}
-	
+
+    public enum Curve: String, Codable {
+        case p256 = "P-256"
+        case p384 = "P-384"
+        case p521 = "P-521"
+        case ed25519 = "Ed25519"
+        case ed448 = "Ed448"
+    }
+    
     /// Supported `kty` key types.
     public enum KeyType: String, Codable {
         /// RSA
         case rsa = "RSA"
         /// ECDSA
         case ecdsa = "EC"
-		/// Octet Key Pair
-		case octetKeyPair = "OKP"
+        /// Octet Key Pair
+        case octetKeyPair = "OKP"
     }
      
     /// The `kty` (key type) parameter identifies the cryptographic algorithm
@@ -43,8 +43,8 @@ public struct JWK: Codable {
         case es384 = "ES384"
         /// EC with SHA512
         case es512 = "ES512"
-		/// EdDSA
-		case eddsa = "EdDSA"
+        /// EdDSA
+        case eddsa = "EdDSA"
     }
      
      /// The `alg` (algorithm) parameter identifies the algorithm intended for
@@ -107,10 +107,10 @@ public struct JWK: Codable {
     public static func ecdsa(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: JWK.Curve?, privateKey: String? = nil) -> JWK {
         return JWK(keyType: .ecdsa, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, y: y, curve: curve)
     }
-	
-	public static func octetKeyPair(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: JWK.Curve?, privateKey: String? = nil) -> JWK {
-		return JWK(keyType: .octetKeyPair, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, curve: curve)
-	}
+    
+    public static func octetKeyPair(_ algorithm: Algorithm?, identifier: JWKIdentifier?, x: String?, y: String?, curve: JWK.Curve?, privateKey: String? = nil) -> JWK {
+        return JWK(keyType: .octetKeyPair, algorithm: algorithm, keyIdentifier: identifier, d: privateKey, x: x, curve: curve)
+    }
     
     private init(
         keyType: KeyType,

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -229,6 +229,16 @@ private struct JWKSigner {
             default:
                 return nil
             }
+				
+		case .octetKeyPair:
+			guard let x = self.jwk.x, let xDecoded = Data(base64Encoded: x.base64UrlEncodedToBase64()) else {
+				return nil
+			}
+
+			return JWTSigner.eddsa(
+				publicKey: xDecoded,
+				privateKey: nil
+			)
         }
     }
 }

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -231,11 +231,19 @@ private struct JWKSigner {
             }
 				
 		case .octetKeyPair:
-			guard let x = self.jwk.x, let key = try? EdDSAKey(x: x, d: self.jwk.privateExponent, curve: self.jwk.curve ?? .ed25519) else {
+			guard let algorithm = algorithm ?? self.jwk.algorithm else {
 				return nil
-			}				
-
-			return JWTSigner.eddsa(key)
+			}
+				
+			switch algorithm {
+				case .eddsa:
+					guard let key = try? EdDSAKey(x: self.jwk.x, d: self.jwk.privateExponent, curve: self.jwk.curve ?? .ed25519) else {
+						return nil
+					}
+					return JWTSigner.eddsa(key)
+				default:
+					return nil
+			}
         }
     }
 }

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -231,11 +231,11 @@ private struct JWKSigner {
             }
 				
 		case .octetKeyPair:
-			guard let x = self.jwk.x, let key = EdDSAKey(x: x, d: self.jwk.privateExponent, curve: self.jwk.curve ?? .ed25519) else {
+			guard let x = self.jwk.x, let key = try? EdDSAKey(x: x, d: self.jwk.privateExponent, curve: self.jwk.curve ?? .ed25519) else {
 				return nil
 			}				
 
-				return JWTSigner.eddsa(key)
+			return JWTSigner.eddsa(key)
         }
     }
 }

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -231,14 +231,11 @@ private struct JWKSigner {
             }
 				
 		case .octetKeyPair:
-			guard let x = self.jwk.x, let xDecoded = Data(base64Encoded: x.base64UrlEncodedToBase64()) else {
+			guard let x = self.jwk.x, let key = EdDSAKey(x: x, d: self.jwk.privateExponent, curve: self.jwk.curve ?? .ed25519) else {
 				return nil
 			}				
 
-			return JWTSigner.eddsa(
-				publicKey: xDecoded,
-				privateKey: nil
-			)
+				return JWTSigner.eddsa(key)
         }
     }
 }

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -198,7 +198,7 @@ private struct JWKSigner {
                 return nil
             }
             
-            let curve: ECDSAKey.Curve
+            let curve: JWK.Curve
             
             if let jwkCurve = self.jwk.curve {
                 curve = jwkCurve
@@ -233,7 +233,7 @@ private struct JWKSigner {
 		case .octetKeyPair:
 			guard let x = self.jwk.x, let xDecoded = Data(base64Encoded: x.base64UrlEncodedToBase64()) else {
 				return nil
-			}
+			}				
 
 			return JWTSigner.eddsa(
 				publicKey: xDecoded,

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -198,9 +198,9 @@ private struct JWKSigner {
                 return nil
             }
             
-            let curve: JWK.Curve
+            let curve: ECDSAKey.Curve
             
-            if let jwkCurve = self.jwk.curve {
+            if let jwkCurve = (self.jwk.curve.flatMap { ECDSAKey.Curve(rawValue: $0.rawValue) }) {
                 curve = jwkCurve
             } else {
                 switch algorithm {
@@ -235,9 +235,11 @@ private struct JWKSigner {
                 return nil
             }
                 
+            let curve = self.jwk.curve.flatMap { EdDSAKey.Curve(rawValue: $0.rawValue) } ?? .ed25519
+            
             switch algorithm {
                 case .eddsa:
-                    guard let key = try? EdDSAKey(x: self.jwk.x, d: self.jwk.privateExponent, curve: self.jwk.curve ?? .ed25519) else {
+                guard let key = try? EdDSAKey(x: self.jwk.x, d: self.jwk.privateExponent, curve: curve) else {
                         return nil
                     }
                     return JWTSigner.eddsa(key)

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -229,21 +229,21 @@ private struct JWKSigner {
             default:
                 return nil
             }
-				
-		case .octetKeyPair:
-			guard let algorithm = algorithm ?? self.jwk.algorithm else {
-				return nil
-			}
-				
-			switch algorithm {
-				case .eddsa:
-					guard let key = try? EdDSAKey(x: self.jwk.x, d: self.jwk.privateExponent, curve: self.jwk.curve ?? .ed25519) else {
-						return nil
-					}
-					return JWTSigner.eddsa(key)
-				default:
-					return nil
-			}
+
+        case .octetKeyPair:
+            guard let algorithm = algorithm ?? self.jwk.algorithm else {
+                return nil
+            }
+                
+            switch algorithm {
+                case .eddsa:
+                    guard let key = try? EdDSAKey(x: self.jwk.x, d: self.jwk.privateExponent, curve: self.jwk.curve ?? .ed25519) else {
+                        return nil
+                    }
+                    return JWTSigner.eddsa(key)
+                default:
+                    return nil
+            }
         }
     }
 }

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -670,6 +670,21 @@ class JWTKitTests: XCTestCase {
             .verify(firebaseJWT, as: FirebasePayload.self)
         XCTAssertEqual(payload.userID, "y8wiKThXGKM88xxrQWDZzKnBuqv2")
     }
+	
+	// MARK: - EdDSA
+	
+	func testEdDSAGenerate() throws {
+		let payload = TestPayload(
+			sub: "vapor",
+			name: "Foo",
+			admin: false,
+			exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+		)
+		let signer = try JWTSigner.eddsa(.generate())
+		let token = try signer.sign(payload)
+		try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
+	}
+
 }
 
 struct AudiencePayload: Codable {

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -681,15 +681,19 @@ class JWTKitTests: XCTestCase {
             exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
         )
         
-        let signer = try JWTSigner.eddsa(.generate())
+        let signer = try JWTSigner.eddsa(.generate(curve: .ed25519))
         let token = try signer.sign(payload)
         try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
     }
     
     func testEdDSAPublicPrivate() throws {
         
-        let publicSigner = try JWTSigner.eddsa(.init(publicKey: Data(base64Encoded: eddsaPublicKeyBase64)))
-        let privateSigner = try JWTSigner.eddsa(.init(privateKey: Data(base64Encoded: eddsaPrivateKeyBae64)))
+        let publicSigner = try JWTSigner.eddsa(
+            .public(x: eddsaPublicKeyBase64, curve: .ed25519)
+        )
+        let privateSigner = try JWTSigner.eddsa(
+            .private(x: eddsaPublicKeyBase64, d: eddsaPrivateKeyBae64, curve: .ed25519)
+        )
 
         let payload = TestPayload(
             sub: "vapor",
@@ -715,7 +719,7 @@ class JWTKitTests: XCTestCase {
         let d = eddsaPrivateKeyBae64
         
         // sign jwt
-        let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+        let signer = try JWTSigner.eddsa(.private(x: x, d: d, curve: .ed25519))
         let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
 
         // verify using jwks
@@ -724,6 +728,7 @@ class JWTKitTests: XCTestCase {
             "keys": [
                 {
                     "kty": "OKP",
+                    "crv": "Ed25519",
                     "use": "sig",
                     "kid": "vapor",
                     "x": "\(x)",
@@ -750,7 +755,7 @@ class JWTKitTests: XCTestCase {
         let d = eddsaPrivateKeyBae64Url
 
         // sign jwt
-        let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+        let signer = try JWTSigner.eddsa(.private(x: x, d: d, curve: .ed25519))
         let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
 
         // verify using jwks without alg
@@ -759,6 +764,7 @@ class JWTKitTests: XCTestCase {
             "keys": [
                 {
                  "kty": "OKP",
+                 "crv": "Ed25519",
                  "use": "sig",
                  "kid": "vapor",
                  "x": "\(x)",
@@ -785,7 +791,7 @@ class JWTKitTests: XCTestCase {
         let d = eddsaPrivateKeyBae64
 
         // sign jwt
-        let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+        let signer = try JWTSigner.eddsa(.private(x: x, d: d, curve: .ed25519))
         let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
 
         // verify using jwks without alg
@@ -794,6 +800,7 @@ class JWTKitTests: XCTestCase {
             "keys": [
                 {
                   "kty": "OKP",
+                  "crv": "Ed25519",
                   "use": "sig",
                   "kid": "vapor",
                   "x": "\(x)",

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -670,144 +670,144 @@ class JWTKitTests: XCTestCase {
             .verify(firebaseJWT, as: FirebasePayload.self)
         XCTAssertEqual(payload.userID, "y8wiKThXGKM88xxrQWDZzKnBuqv2")
     }
-	
-	// MARK: - EdDSA
-	
-	func testEdDSAGenerate() throws {
-		let payload = TestPayload(
-			sub: "vapor",
-			name: "Foo",
-			admin: false,
-			exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
-		)
-		
-		let signer = try JWTSigner.eddsa(.generate())
-		let token = try signer.sign(payload)
-		try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
-	}
-	
-	func testEdDSAPublicPrivate() throws {
-		
-		let publicSigner = try JWTSigner.eddsa(.init(publicKey: Data(base64Encoded: eddsaPublicKeyBase64)))
-		let privateSigner = try JWTSigner.eddsa(.init(privateKey: Data(base64Encoded: eddsaPrivateKeyBae64)))
+    
+    // MARK: - EdDSA
+    
+    func testEdDSAGenerate() throws {
+        let payload = TestPayload(
+            sub: "vapor",
+            name: "Foo",
+            admin: false,
+            exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+        )
+        
+        let signer = try JWTSigner.eddsa(.generate())
+        let token = try signer.sign(payload)
+        try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
+    }
+    
+    func testEdDSAPublicPrivate() throws {
+        
+        let publicSigner = try JWTSigner.eddsa(.init(publicKey: Data(base64Encoded: eddsaPublicKeyBase64)))
+        let privateSigner = try JWTSigner.eddsa(.init(privateKey: Data(base64Encoded: eddsaPrivateKeyBae64)))
 
-		let payload = TestPayload(
-			sub: "vapor",
-			name: "Foo",
-			admin: false,
-			exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
-		)
-		for _ in 0..<1_000 {
-			let token = try privateSigner.sign(payload)
-			// test public signer decoding
-			try XCTAssertEqual(publicSigner.verify(token, as: TestPayload.self), payload)
-		}
-	}
-		
-	func testVerifyingEdDSAKeyUsingJWK() throws {
-		struct Foo: JWTPayload {
-			var bar: Int
-			func verify(using signer: JWTSigner) throws { }
-		}
-				
-		// ecdsa key in base64 format
-		let x = eddsaPublicKeyBase64
-		let d = eddsaPrivateKeyBae64
-		
-		// sign jwt
-		let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
-		let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
+        let payload = TestPayload(
+            sub: "vapor",
+            name: "Foo",
+            admin: false,
+            exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+        )
+        for _ in 0..<1_000 {
+            let token = try privateSigner.sign(payload)
+            // test public signer decoding
+            try XCTAssertEqual(publicSigner.verify(token, as: TestPayload.self), payload)
+        }
+    }
+        
+    func testVerifyingEdDSAKeyUsingJWK() throws {
+        struct Foo: JWTPayload {
+            var bar: Int
+            func verify(using signer: JWTSigner) throws { }
+        }
+                
+        // ecdsa key in base64 format
+        let x = eddsaPublicKeyBase64
+        let d = eddsaPrivateKeyBae64
+        
+        // sign jwt
+        let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+        let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
 
-		// verify using jwks
-		let jwksString = """
-		{
-			"keys": [
-				{
-					"kty": "OKP",
-					"use": "sig",
-					"kid": "vapor",
-					"x": "\(x)",
-					"d": "\(d)"
-				 }
-			]
-		}
-		"""
+        // verify using jwks
+        let jwksString = """
+        {
+            "keys": [
+                {
+                    "kty": "OKP",
+                    "use": "sig",
+                    "kid": "vapor",
+                    "x": "\(x)",
+                    "d": "\(d)"
+                 }
+            ]
+        }
+        """
 
-		let signers = JWTSigners()
-		try signers.use(jwksJSON: jwksString)
-		let foo = try signers.verify(jwt, as: Foo.self)
-		XCTAssertEqual(foo.bar, 42)
-	}
-	
-	func testVerifyingEdDSAKeyUsingJWKBase64URL() throws {
-		struct Foo: JWTPayload {
-			var bar: Int
-			func verify(using signer: JWTSigner) throws { }
-		}
-				
-		// eddsa key in base64url format
-		let x = eddsaPublicKeyBase64Url
-		let d = eddsaPrivateKeyBae64Url
+        let signers = JWTSigners()
+        try signers.use(jwksJSON: jwksString)
+        let foo = try signers.verify(jwt, as: Foo.self)
+        XCTAssertEqual(foo.bar, 42)
+    }
+    
+    func testVerifyingEdDSAKeyUsingJWKBase64URL() throws {
+        struct Foo: JWTPayload {
+            var bar: Int
+            func verify(using signer: JWTSigner) throws { }
+        }
+                
+        // eddsa key in base64url format
+        let x = eddsaPublicKeyBase64Url
+        let d = eddsaPrivateKeyBae64Url
 
-		// sign jwt
-		let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
-		let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
+        // sign jwt
+        let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+        let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
 
-		// verify using jwks without alg
-		let jwksString = """
-		{
-			"keys": [
-				{
-				 "kty": "OKP",
-				 "use": "sig",
-				 "kid": "vapor",
-				 "x": "\(x)",
-				 "d": "\(d)"
-				 }
-			]
-		}
-		"""
+        // verify using jwks without alg
+        let jwksString = """
+        {
+            "keys": [
+                {
+                 "kty": "OKP",
+                 "use": "sig",
+                 "kid": "vapor",
+                 "x": "\(x)",
+                 "d": "\(d)"
+                 }
+            ]
+        }
+        """
 
-		let signers = JWTSigners()
-		try signers.use(jwksJSON: jwksString)
-		let foo = try signers.verify(jwt, as: Foo.self)
-		XCTAssertEqual(foo.bar, 42)
-	}
-		
-	func testVerifyingEdDSAKeyUsingJWKWithMixedBase64Formats() throws {
-		struct Foo: JWTPayload {
-			var bar: Int
-			func verify(using signer: JWTSigner) throws { }
-		}
-				
-		// eddsa key in base64url format
-		let x = eddsaPublicKeyBase64Url
-		let d = eddsaPrivateKeyBae64
+        let signers = JWTSigners()
+        try signers.use(jwksJSON: jwksString)
+        let foo = try signers.verify(jwt, as: Foo.self)
+        XCTAssertEqual(foo.bar, 42)
+    }
+        
+    func testVerifyingEdDSAKeyUsingJWKWithMixedBase64Formats() throws {
+        struct Foo: JWTPayload {
+            var bar: Int
+            func verify(using signer: JWTSigner) throws { }
+        }
+                
+        // eddsa key in base64url format
+        let x = eddsaPublicKeyBase64Url
+        let d = eddsaPrivateKeyBae64
 
-		// sign jwt
-		let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
-		let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
+        // sign jwt
+        let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+        let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
 
-		// verify using jwks without alg
-		let jwksString = """
-		{
-			"keys": [
-				{
-				  "kty": "OKP",
-				  "use": "sig",
-				  "kid": "vapor",
-				  "x": "\(x)",
-				  "d": "\(d)"
-				 }
-			]
-		}
-		"""
+        // verify using jwks without alg
+        let jwksString = """
+        {
+            "keys": [
+                {
+                  "kty": "OKP",
+                  "use": "sig",
+                  "kid": "vapor",
+                  "x": "\(x)",
+                  "d": "\(d)"
+                 }
+            ]
+        }
+        """
 
-		let signers = JWTSigners()
-		try signers.use(jwksJSON: jwksString)
-		let foo = try signers.verify(jwt, as: Foo.self)
-		XCTAssertEqual(foo.bar, 42)
-	}
+        let signers = JWTSigners()
+        try signers.use(jwksJSON: jwksString)
+        let foo = try signers.verify(jwt, as: Foo.self)
+        XCTAssertEqual(foo.bar, 42)
+    }
 
 }
 

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -680,9 +680,141 @@ class JWTKitTests: XCTestCase {
 			admin: false,
 			exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
 		)
+		
+		let key = try EdDSAKey.generate()
+		
 		let signer = try JWTSigner.eddsa(.generate())
 		let token = try signer.sign(payload)
 		try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
+	}
+	
+	func testEdDSAPublicPrivate() throws {
+		let signer = try JWTSigner.eddsa(
+			.init(
+				publicKey: Data(base64Encoded: eddsaPublicKeyBase64)!,
+				privateKey: Data(base64Encoded: eddsaPrivateKeyBae64)!,
+				curve: .ed25519
+			)
+		)
+
+		let payload = TestPayload(
+			sub: "vapor",
+			name: "Foo",
+			admin: false,
+			exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+		)
+		for _ in 0..<1_000 {
+			let token = try signer.sign(payload)
+			// test private signer decoding
+			try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
+			// test public signer decoding
+			try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
+		}
+	}
+		
+	func testVerifyingEdDSAKeyUsingJWK() throws {
+		struct Foo: JWTPayload {
+			var bar: Int
+			func verify(using signer: JWTSigner) throws { }
+		}
+				
+		// ecdsa key in base64 format
+		let x = eddsaPublicKeyBase64
+		let d = eddsaPrivateKeyBae64
+		
+		// sign jwt
+		let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+		let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
+
+		// verify using jwks
+		let jwksString = """
+		{
+			"keys": [
+				{
+					"kty": "OKP",
+					"use": "sig",
+					"kid": "vapor",
+					"x": "\(x)",
+					"d": "\(d)"
+				 }
+			]
+		}
+		"""
+
+		let signers = JWTSigners()
+		try signers.use(jwksJSON: jwksString)
+		let foo = try signers.verify(jwt, as: Foo.self)
+		XCTAssertEqual(foo.bar, 42)
+	}
+	
+	func testVerifyingEdDSAKeyUsingJWKBase64URL() throws {
+		struct Foo: JWTPayload {
+			var bar: Int
+			func verify(using signer: JWTSigner) throws { }
+		}
+				
+		// eddsa key in base64url format
+		let x = eddsaPublicKeyBase64Url
+		let d = eddsaPrivateKeyBae64Url
+
+		// sign jwt
+		let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+		let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
+
+		// verify using jwks without alg
+		let jwksString = """
+		{
+			"keys": [
+				{
+				 "kty": "OKP",
+				 "use": "sig",
+				 "kid": "vapor",
+				 "x": "\(x)",
+				 "d": "\(d)"
+				 }
+			]
+		}
+		"""
+
+		let signers = JWTSigners()
+		try signers.use(jwksJSON: jwksString)
+		let foo = try signers.verify(jwt, as: Foo.self)
+		XCTAssertEqual(foo.bar, 42)
+	}
+		
+	func testVerifyingEdDSAKeyUsingJWKWithMixedBase64Formats() throws {
+		struct Foo: JWTPayload {
+			var bar: Int
+			func verify(using signer: JWTSigner) throws { }
+		}
+				
+		// eddsa key in base64url format
+		let x = eddsaPublicKeyBase64Url
+		let d = eddsaPrivateKeyBae64
+
+		// sign jwt
+		let signer = try JWTSigner.eddsa(.init(x: x, d: d, curve: .ed25519))
+		let jwt = try signer.sign(Foo(bar: 42), kid: "vapor")
+
+		// verify using jwks without alg
+		let jwksString = """
+		{
+			"keys": [
+				{
+				  "kty": "OKP",
+				  "use": "sig",
+				  "kid": "vapor",
+				  "x": "\(x)",
+				  "d": "\(d)"
+				 }
+			]
+		}
+		"""
+
+		let signers = JWTSigners()
+		try signers.use(jwksJSON: jwksString)
+		let foo = try signers.verify(jwt, as: Foo.self)
+		XCTAssertEqual(foo.bar, 42)
 	}
 
 }
@@ -849,6 +981,11 @@ MA0GCSqGSIb3DQEBCwUAA0EAQyBP1X40S4joTg1ov4eK0aKNlRLbWftEorGh5jCc
 F3IAwlztc7uFj589k/M+xO4TGdrEVlMyiVdC5/B0MLa8LQ==
 -----END CERTIFICATE-----
 """
+
+let eddsaPublicKeyBase64 = "0ZcEvMCSYqSwR8XIkxOoaYjRQSAO8frTMSCpNbUl4lE="
+let eddsaPrivateKeyBae64 = "d1H3/dcg0V3XyAuZW2TE5Z3rhY20M+4YAfYu/HUQd8w="
+let eddsaPublicKeyBase64Url = "0ZcEvMCSYqSwR8XIkxOoaYjRQSAO8frTMSCpNbUl4lE"
+let eddsaPrivateKeyBae64Url = "d1H3_dcg0V3XyAuZW2TE5Z3rhY20M-4YAfYu_HUQd8w"
 
 struct FirebasePayload: JWTPayload, Equatable {
     enum CodingKeys: String, CodingKey {

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -681,21 +681,15 @@ class JWTKitTests: XCTestCase {
 			exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
 		)
 		
-		let key = try EdDSAKey.generate()
-		
 		let signer = try JWTSigner.eddsa(.generate())
 		let token = try signer.sign(payload)
 		try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
 	}
 	
 	func testEdDSAPublicPrivate() throws {
-		let signer = try JWTSigner.eddsa(
-			.init(
-				publicKey: Data(base64Encoded: eddsaPublicKeyBase64)!,
-				privateKey: Data(base64Encoded: eddsaPrivateKeyBae64)!,
-				curve: .ed25519
-			)
-		)
+		
+		let publicSigner = try JWTSigner.eddsa(.init(publicKey: Data(base64Encoded: eddsaPublicKeyBase64)))
+		let privateSigner = try JWTSigner.eddsa(.init(privateKey: Data(base64Encoded: eddsaPrivateKeyBae64)))
 
 		let payload = TestPayload(
 			sub: "vapor",
@@ -704,11 +698,9 @@ class JWTKitTests: XCTestCase {
 			exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
 		)
 		for _ in 0..<1_000 {
-			let token = try signer.sign(payload)
-			// test private signer decoding
-			try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
+			let token = try privateSigner.sign(payload)
 			// test public signer decoding
-			try XCTAssertEqual(signer.verify(token, as: TestPayload.self), payload)
+			try XCTAssertEqual(publicSigner.verify(token, as: TestPayload.self), payload)
 		}
 	}
 		


### PR DESCRIPTION
This implements support for Octet Key Pairs ([RFC8037](https://www.rfc-editor.org/rfc/rfc8037.html#section-2)) with the EdDSA algorithm and ED25519 curves. It closes #50.