### PR TITLE
Add zip header (deflated body) support and documentation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,13 +16,15 @@ let package = Package(
         MANGLE_END */
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
+		.package(url: "https://github.com/tsolomko/SWCompression.git", from: "4.7.0")
     ],
     targets: [
         .target(name: "CJWTKitBoringSSL"),
         .target(name: "JWTKit", dependencies: [
             .target(name: "CJWTKitBoringSSL"),
             .product(name: "Crypto", package: "swift-crypto"),
+			.product(name: "SWCompression", package: "SWCompression")
         ]),
         .testTarget(name: "JWTKitTests", dependencies: [
             .target(name: "JWTKit"),

--- a/Sources/JWTKit/JWTCompression.swift
+++ b/Sources/JWTKit/JWTCompression.swift
@@ -4,15 +4,15 @@ import protocol SWCompression.DecompressionAlgorithm
 import protocol SWCompression.CompressionAlgorithm
 
 /// The supported compression types for a JWT's body.
-public enum CompressionTypes: String {
-    /// Deflate (Gzip) compression.
+public enum CompressionType: String {
+    /// Deflate compression.
     case deflate = "DEF"
 }
 
 /// Types that can both compress and decompress data.
 typealias CompressableAlgorithm = DecompressionAlgorithm & CompressionAlgorithm
 
-extension CompressionTypes {
+extension CompressionType {
     /// The decompression algorithm for the compression type.
     var algorithm: CompressableAlgorithm.Type {
         switch self {

--- a/Sources/JWTKit/JWTCompression.swift
+++ b/Sources/JWTKit/JWTCompression.swift
@@ -1,0 +1,24 @@
+import Foundation
+import class SWCompression.Deflate
+import protocol SWCompression.DecompressionAlgorithm
+import protocol SWCompression.CompressionAlgorithm
+
+/// The supported compression types for a JWT's body.
+public enum CompressionTypes: String {
+    /// Deflate (Gzip) compression.
+    case deflate = "DEF"
+}
+
+/// Types that can both compress and decompress data.
+typealias CompressableAlgorithm = DecompressionAlgorithm & CompressionAlgorithm
+
+extension CompressionTypes {
+    /// The decompression algorithm for the compression type.
+    var algorithm: CompressableAlgorithm.Type {
+        switch self {
+            case .deflate:
+                return Deflate.self
+        }
+    }
+}
+

--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -8,6 +8,7 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
     case missingKIDHeader
     case unknownKID(JWKIdentifier)
     case invalidJWK
+	case invalidCompression
     case invalidBool(String)
     case generic(identifier: String, reason: String)
 
@@ -27,6 +28,8 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
             return "unknown kid: \(kid)"
         case .invalidJWK:
             return "invalid JWK"
+		case .invalidCompression:
+			return "compression type not supported"
         case .invalidBool(let str):
             return "invalid boolean value: \(str)"
         case .generic(let identifier, let reason):

--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -8,7 +8,7 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
     case missingKIDHeader
     case unknownKID(JWKIdentifier)
     case invalidJWK
-    case invalidCompression
+    case invalidCompression(algorithm: String)
     case invalidBool(String)
     case generic(identifier: String, reason: String)
 
@@ -28,8 +28,8 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
             return "unknown kid: \(kid)"
         case .invalidJWK:
             return "invalid JWK"
-        case .invalidCompression:
-            return "compression type not supported"
+        case .invalidCompression(let algorithm):
+            return "compression type \"\(algorithm)\" not supported"
         case .invalidBool(let str):
             return "invalid boolean value: \(str)"
         case .generic(let identifier, let reason):

--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -8,7 +8,7 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
     case missingKIDHeader
     case unknownKID(JWKIdentifier)
     case invalidJWK
-	case invalidCompression
+    case invalidCompression
     case invalidBool(String)
     case generic(identifier: String, reason: String)
 
@@ -28,8 +28,8 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
             return "unknown kid: \(kid)"
         case .invalidJWK:
             return "invalid JWK"
-		case .invalidCompression:
-			return "compression type not supported"
+        case .invalidCompression:
+            return "compression type not supported"
         case .invalidBool(let str):
             return "invalid boolean value: \(str)"
         case .generic(let identifier, let reason):

--- a/Sources/JWTKit/JWTHeader.swift
+++ b/Sources/JWTKit/JWTHeader.swift
@@ -15,7 +15,7 @@ struct JWTHeader: Codable {
     /// The JWT key identifier.
     var kid: JWKIdentifier?
 
-	/// The type of compression applied to the payload, if any.
-	var zip: String?
+    /// The type of compression applied to the payload, if any.
+    var zip: String?
 }
 

--- a/Sources/JWTKit/JWTHeader.swift
+++ b/Sources/JWTKit/JWTHeader.swift
@@ -14,5 +14,8 @@ struct JWTHeader: Codable {
 
     /// The JWT key identifier.
     var kid: JWKIdentifier?
+
+	/// The type of compression applied to the payload, if any.
+	var zip: String?
 }
 

--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -28,14 +28,14 @@ struct JWTParser {
     func payload<Payload>(as payload: Payload.Type) throws -> Payload
         where Payload: JWTPayload
     {
-		var decodedPayload = Data(self.encodedPayload.base64URLDecodedBytes())
+        var decodedPayload = Data(self.encodedPayload.base64URLDecodedBytes())
 
-		if let compressionType = try self.header().zip {
-			guard compressionType == "DEF" else {
-				throw JWTError.invalidCompression
-			}
-			decodedPayload = try Deflate.decompress(data: decodedPayload)
-		}
+        if let compressionType = try self.header().zip {
+            guard compressionType == "DEF" else {
+                throw JWTError.invalidCompression
+            }
+            decodedPayload = try Deflate.decompress(data: decodedPayload)
+        }
 
         return try self.jsonDecoder()
             .decode(Payload.self, from: decodedPayload)

--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -33,6 +33,7 @@ struct JWTParser {
         if let compressionType = try self.header().zip {
             guard compressionType == "DEF" else {
                 throw JWTError.invalidCompression
+                throw JWTError.invalidCompression(algorithm: compressionType)
             }
             decodedPayload = try Deflate.decompress(data: decodedPayload)
         }

--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -31,11 +31,10 @@ struct JWTParser {
         var decodedPayload = Data(self.encodedPayload.base64URLDecodedBytes())
 
         if let compressionType = try self.header().zip {
-            guard compressionType == "DEF" else {
-                throw JWTError.invalidCompression
+            guard let compressionType = CompressionTypes(rawValue: compressionType) else {
                 throw JWTError.invalidCompression(algorithm: compressionType)
             }
-            decodedPayload = try Deflate.decompress(data: decodedPayload)
+            decodedPayload = try compressionType.algorithm.decompress(data: decodedPayload)
         }
 
         return try self.jsonDecoder()

--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -2,14 +2,16 @@ import class Foundation.JSONDecoder
 import struct Foundation.Data
 import class SWCompression.Deflate
 
+/// A type for parsing JWTs from raw data.
 struct JWTParser {
     let encodedHeader: ArraySlice<UInt8>
     let encodedPayload: ArraySlice<UInt8>
     let encodedSignature: ArraySlice<UInt8>
 
-    init<Token>(token: Token) throws
-        where Token: DataProtocol
-    {
+    /// Initialize a JWTParser with raw token data.
+    /// - Parameters:
+    ///   - token: The raw data of the token (must conform to `DataProtocol`).
+    init<Token: DataProtocol>(token: Token) throws {
         let tokenParts = token.copyBytes()
             .split(separator: .period, omittingEmptySubsequences: false)
         guard tokenParts.count == 3 else {
@@ -20,11 +22,15 @@ struct JWTParser {
         self.encodedSignature = tokenParts[2]
     }
 
+    /// Parses the header data into a `JWTHeader`.
     func header() throws -> JWTHeader {
         try self.jsonDecoder()
             .decode(JWTHeader.self, from: .init(self.encodedHeader.base64URLDecodedBytes()))
     }
 
+    /// Parses the payload data into a given payload type, accounting for compression specified in the header.
+    /// - Parameters:
+    ///   - payload: The type of payload to parse to.
     func payload<Payload>(as payload: Payload.Type) throws -> Payload
         where Payload: JWTPayload
     {
@@ -41,20 +47,26 @@ struct JWTParser {
             .decode(Payload.self, from: decodedPayload)
     }
 
+    /// Verify the parsed token using a given signer.
+    /// - Parameters:
+    ///   - signer: The `JWTSigner` to use for verification.
     func verify(using signer: JWTSigner) throws {
         guard try signer.algorithm.verify(self.signature, signs: self.message) else {
             throw JWTError.signatureVerifictionFailed
         }
     }
 
+    /// The raw bytes of the token's signature.
     private var signature: [UInt8] {
         self.encodedSignature.base64URLDecodedBytes()
     }
 
+    /// The message of the token (without the signature).
     private var message: ArraySlice<UInt8> {
         self.encodedHeader + [.period] + self.encodedPayload
     }
 
+    /// A `JSONDecoder` with the proper settings for JWTs.
     private func jsonDecoder() -> JSONDecoder {
         let jsonDecoder = JSONDecoder()
         jsonDecoder.dateDecodingStrategy = .secondsSince1970

--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -31,7 +31,7 @@ struct JWTParser {
         var decodedPayload = Data(self.encodedPayload.base64URLDecodedBytes())
 
         if let compressionType = try self.header().zip {
-            guard let compressionType = CompressionTypes(rawValue: compressionType) else {
+            guard let compressionType = CompressionType(rawValue: compressionType) else {
                 throw JWTError.invalidCompression(algorithm: compressionType)
             }
             decodedPayload = try compressionType.algorithm.decompress(data: decodedPayload)

--- a/Sources/JWTKit/JWTSerializer.swift
+++ b/Sources/JWTKit/JWTSerializer.swift
@@ -27,9 +27,8 @@ struct JWTSerializer {
 
         // encode payload
         let payloadData = try jsonEncoder.encode(payload)
-
         let encodedPayload: [UInt8]
-
+        
         if let compressionAlgorithm = zip {
             // if a compression algorithm was specified, compress the data before base64ing it
             let compressedData = try compressionAlgorithm.algorithm.compress(data: payloadData)

--- a/Sources/JWTKit/JWTSerializer.swift
+++ b/Sources/JWTKit/JWTSerializer.swift
@@ -1,16 +1,23 @@
 import class Foundation.JSONEncoder
 
+/// A type for taking a JWT and generating, signing, and encoding it.
 struct JWTSerializer {
-    func sign<Payload>(
+    /// Signs a JWT with a given payload, signer, and header values.
+    /// - Parameters:
+    ///   - payload: The JWT's payload type. Must conform to `JWTPayload`.
+    ///   - signer: The `JWTSigner` to use for the token's signature.
+    ///   - typ: The signature's content type. Defaults to "JWT".
+    ///   - kid: The key ID for the token (if any).
+    ///   - cty: The payload's content type (if any).
+    ///   - zip: The compression type to use for the payload (if any).
+    func sign<Payload: JWTPayload>(
         _ payload: Payload,
         using signer: JWTSigner,
         typ: String = "JWT",
         kid: JWKIdentifier? = nil,
         cty: String? = nil,
         zip: CompressionType? = nil
-    ) throws -> String
-        where Payload: JWTPayload
-    {
+    ) throws -> String {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.dateEncodingStrategy = .secondsSince1970
 

--- a/Sources/JWTKit/JWTSigner.swift
+++ b/Sources/JWTKit/JWTSigner.swift
@@ -10,11 +10,12 @@ public final class JWTSigner {
         _ payload: Payload,
         typ: String = "JWT",
         kid: JWKIdentifier? = nil,
-        cty: String? = nil
+        cty: String? = nil,
+        zip: CompressionType? = nil
     ) throws -> String
         where Payload: JWTPayload
     {
-        try JWTSerializer().sign(payload, using: self, typ: typ, kid: kid, cty: cty)
+        try JWTSerializer().sign(payload, using: self, typ: typ, kid: kid, cty: cty, zip: zip)
     }
 
     public func unverified<Payload>(

--- a/Sources/JWTKit/JWTSigner.swift
+++ b/Sources/JWTKit/JWTSigner.swift
@@ -2,62 +2,77 @@
 public final class JWTSigner {
     public let algorithm: JWTAlgorithm
 
+    /// Set up the signer with a given algorithm.
     public init(algorithm: JWTAlgorithm) {
         self.algorithm = algorithm
     }
 
-    public func sign<Payload>(
+    /// Signs a JWT with a given payload and appropriate header values.
+    /// - Parameters:
+    ///   - payload: The JWT's payload type. Must conform to `JWTPayload`.
+    ///   - typ: The signature's content type. Defaults to "JWT".
+    ///   - kid: The key ID for the token (if any).
+    ///   - cty: The payload's content type (if any).
+    ///   - zip: The compression type to use for the payload (if any).
+    public func sign<Payload: JWTPayload>(
         _ payload: Payload,
         typ: String = "JWT",
         kid: JWKIdentifier? = nil,
         cty: String? = nil,
         zip: CompressionType? = nil
-    ) throws -> String
-        where Payload: JWTPayload
-    {
+    ) throws -> String {
         try JWTSerializer().sign(payload, using: self, typ: typ, kid: kid, cty: cty, zip: zip)
     }
 
-    public func unverified<Payload>(
+    /// Parses a given token without verifying it.
+    /// - Parameters:
+    ///   - token: The string containing the encoded token.
+    ///   - payload: The type to parse the payload as. Must conform to `JWTPayload`.
+    public func unverified<Payload: JWTPayload>(
         _ token: String,
         as payload: Payload.Type = Payload.self
-    ) throws -> Payload
-        where Payload: JWTPayload
-    {
+    ) throws -> Payload {
         try self.unverified([UInt8](token.utf8))
     }
 
-    public func unverified<Message, Payload>(
+    /// Parses a given token without verifying it.
+    /// - Parameters:
+    ///   - token: The instance of `DataProtocol` containing the encoded token.
+    ///   - payload: The type to parse the payload as. Must conform to `JWTPayload`.
+    public func unverified<Message: DataProtocol, Payload: JWTPayload>(
         _ token: Message,
         as payload: Payload.Type = Payload.self
-    ) throws -> Payload
-        where Message: DataProtocol, Payload: JWTPayload
-    {
+    ) throws -> Payload {
         try JWTParser(token: token).payload(as: Payload.self)
     }
 
-    public func verify<Payload>(
+    /// Verifies and parses a given token, throwing an error if the signature is invalid.
+    /// - Parameters:
+    ///   - token: The string containing the encoded token.
+    ///   - payload: The type to parse the payload as. Must conform to `JWTPayload`.
+    public func verify<Payload: JWTPayload>(
         _ token: String,
         as payload: Payload.Type = Payload.self
-    ) throws -> Payload
-        where Payload: JWTPayload
-    {
+    ) throws -> Payload {
         try self.verify([UInt8](token.utf8), as: Payload.self)
     }
 
-    public func verify<Message, Payload>(
+    /// Verifies and parses a given token, throwing an error if the signature is invalid.
+    /// - Parameters:
+    ///   - token: The instance of `DataProtocol` containing the encoded token.
+    ///   - payload: The type to parse the payload as. Must conform to `JWTPayload`.
+    public func verify<Message: DataProtocol, Payload: JWTPayload>(
         _ token: Message,
         as payload: Payload.Type = Payload.self
-    ) throws -> Payload
-        where Message: DataProtocol, Payload: JWTPayload
-    {
+    ) throws -> Payload {
         let parser = try JWTParser(token: token)
         return try self.verify(parser: parser)
     }
 
-    func verify<Payload>(parser: JWTParser) throws -> Payload
-        where Payload: JWTPayload
-    {
+    /// Verifies and parses a given token using a pre-initialized `JWTParser`.
+    /// - Parameters:
+    ///   - parser: The `JWTParser` initialized with the token.
+    func verify<Payload: JWTPayload>(parser: JWTParser) throws -> Payload {
         try parser.verify(using: self)
         let payload = try parser.payload(as: Payload.self)
         try payload.verify(using: self)

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -133,7 +133,8 @@ public final class JWTSigners {
     public func sign<Payload>(
         _ payload: Payload,
         typ: String = "JWT",
-        kid: JWKIdentifier? = nil
+        kid: JWKIdentifier? = nil,
+        zip: CompressionType? = nil
     ) throws -> String
         where Payload: JWTPayload
     {
@@ -141,7 +142,8 @@ public final class JWTSigners {
             payload,
             using: self.require(kid: kid),
             typ: typ,
-            kid: kid
+            kid: kid,
+            zip: zip
         )
     }
 }

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -18,6 +18,10 @@ public final class JWTSigners {
     }
 
     /// Adds a new signer.
+    /// - Parameters:
+    ///   - signer: The `JWTSigner` to add.
+    ///   - kid: The key ID to use for the new signer (if any).
+    ///   - isDefault: Whether to use this signer as the default.
     public func use(
         _ signer: JWTSigner,
         kid: JWKIdentifier? = nil,
@@ -80,6 +84,7 @@ public final class JWTSigners {
         }
     }
 
+    /// Gets a signer for the supplied `kid`, throwing a `JWTError` if one doesn't exist.
     public func require(kid: JWKIdentifier? = nil, alg: String? = nil) throws -> JWTSigner {
         guard let signer = self.get(kid: kid, alg: alg) else {
             if let kid = kid {
@@ -91,53 +96,65 @@ public final class JWTSigners {
         return signer
     }
 
-    public func unverified<Payload>(
+    /// Parses a given token without verifying it.
+    /// - Parameters:
+    ///   - token: The string containing the encoded token.
+    ///   - payload: The type to parse the payload as. Must conform to `JWTPayload`.
+    public func unverified<Payload: JWTPayload>(
         _ token: String,
         as payload: Payload.Type = Payload.self
-    ) throws -> Payload
-        where Payload: JWTPayload
-    {
+    ) throws -> Payload {
         try self.unverified([UInt8](token.utf8))
     }
 
-    public func unverified<Message, Payload>(
+    /// Parses a given token without verifying it.
+    /// - Parameters:
+    ///   - token: The instance of `DataProtocol` containing the encoded token.
+    ///   - payload: The type to parse the payload as. Must conform to `JWTPayload`.
+    public func unverified<Message: DataProtocol, Payload: JWTPayload>(
         _ token: Message,
         as payload: Payload.Type = Payload.self
-    ) throws -> Payload
-        where Message: DataProtocol, Payload: JWTPayload
-    {
+    ) throws -> Payload {
         try JWTParser(token: token).payload(as: Payload.self)
     }
 
-
-    public func verify<Payload>(
+    /// Verifies and parses a given token, throwing an error if the signature is invalid.
+    /// - Parameters:
+    ///   - token: The string containing the encoded token.
+    ///   - payload: The type to parse the payload as. Must conform to `JWTPayload`.
+    public func verify<Payload: JWTPayload>(
         _ token: String,
         as payload: Payload.Type = Payload.self
-    ) throws -> Payload
-        where Payload: JWTPayload
-    {
+    ) throws -> Payload {
         try self.verify([UInt8](token.utf8), as: Payload.self)
     }
 
-    public func verify<Message, Payload>(
+    /// Verifies and parses a given token, throwing an error if the signature is invalid.
+    /// - Parameters:
+    ///   - token: The instance of `DataProtocol` containing the encoded token.
+    ///   - payload: The type to parse the payload as. Must conform to `JWTPayload`.
+    public func verify<Message: DataProtocol, Payload: JWTPayload>(
         _ token: Message,
         as payload: Payload.Type = Payload.self
-    ) throws -> Payload
-        where Message: DataProtocol, Payload: JWTPayload
-    {
+    ) throws -> Payload {
         let parser = try JWTParser(token: token)
         let header = try parser.header()
         return try self.require(kid: header.kid, alg: header.alg).verify(parser: parser)
     }
 
-    public func sign<Payload>(
+
+    /// Signs a JWT with a given payload and appropriate header values.
+    /// - Parameters:
+    ///   - payload: The JWT's payload type. Must conform to `JWTPayload`.
+    ///   - typ: The signature's content type. Defaults to "JWT".
+    ///   - kid: The key ID for the token (if any). This is used to fetch the signer that will be used (as set up with `func use(_ signer: JWTSigner, kid: JWKIdentifier?, isDefault: )`
+    ///   - zip: The compression type to use for the payload (if any).
+    public func sign<Payload: JWTPayload>(
         _ payload: Payload,
         typ: String = "JWT",
         kid: JWKIdentifier? = nil,
         zip: CompressionType? = nil
-    ) throws -> String
-        where Payload: JWTPayload
-    {
+    ) throws -> String {
         return try JWTSerializer().sign(
             payload,
             using: self.require(kid: kid),
@@ -148,13 +165,21 @@ public final class JWTSigners {
     }
 }
 
+/// A type that takes a JWK and gives a signer from the value.
 private struct JWKSigner {
+    /// The JWK to generate a signer from.
     let jwk: JWK
 
+    /// Set up a `JWKSigner` with a given `JWK`.
     init(jwk: JWK) {
         self.jwk = jwk
     }
 
+    /// A signer generated from the JWK.
+    /// - Parameters:
+    ///   - algorithm: An optional `JWK.Algorithm` value. If provided, it overrides the
+    ///   algorithm set in the JWK. If there's no provided algorithm in both the call and the JWK,
+    ///   the function returns nil.
     func signer(for algorithm: JWK.Algorithm? = nil) -> JWTSigner? {
         switch self.jwk.keyType {
         case .rsa:

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -643,6 +643,25 @@ class JWTKitTests: XCTestCase {
         XCTAssertEqual(foo.bar, 42)
     }
 
+    func testDeflate() throws {
+        let test = TestPayload(
+            sub: "vapor",
+            name: "foo",
+            admin: true,
+            exp: .init(value: .distantFuture)
+        )
+
+        let jwt = try JWTSigner.es256(
+            key: .private(pem: ecdsaPrivateKey)
+        ).sign(test, zip: .deflate)
+
+        let payload = try JWTSigner.es256(
+            key: .public(pem: ecdsaPublicKey)
+        ).verify(jwt, as: TestPayload.self)
+
+        XCTAssertEqual(test, payload)
+    }
+
     func testMicrosoftJWKs() throws {
         let signers = JWTSigners()
         try signers.use(jwksJSON: microsoftJWKS)


### PR DESCRIPTION
This PR should add support for JWTs with the `"zip": "DEF"` header. 

It does this by using SWCompression, which is unfortunately made necessary by the lack of compression APIs in Foundation on Linux. If anyone has ideas for getting around this, they would be extremely welcome (I considered copying just the necessary files from the dependency and giving appropriate credit, but decided against it for maintainability).

This PR also adds some documentation for `JWTParser`, `JWTSerializer`, `JWTSigner`, and `JWTSigners`.