### PR TITLE
Add support to PSS algorithm family

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ JWTKit provides APIs for signing and verifying JSON Web Tokens ([RFC7519](https:
 
 - Verifying (parsing)
 - Signing (serializing)
-- RSA (RS256, RS384, RS512)
+- RSA (RS256, RS384, RS512, PS256, PS384, PS512)
 - ECDSA (ES256, ES384, ES512)
 - HMAC (HS256, HS384, HS512)
 - Claims (aud, exp, iss, etc)
@@ -275,6 +275,10 @@ Once you have the RSAKey, you can use it to create an RSA signer.
 - `rs256`: RSA with SHA-256
 - `rs384`: RSA with SHA-384
 - `rs512`: RSA with SHA-512
+- `ps256`: RSASSA-PSS with SHA-256 and MGF1 with SHA-256
+- `ps384`: RSASSA-PSS with SHA-384 and MGF1 with SHA-384
+- `ps512`: RSASSA-PSS with SHA-512 and MGF1 with SHA-512
+
 
 ```swift
 // Add RSA with SHA-256 signer.

--- a/Sources/JWTKit/JWK/JWK.swift
+++ b/Sources/JWTKit/JWK/JWK.swift
@@ -26,6 +26,12 @@ public struct JWK: Codable {
         case rs384 = "RS384"
         /// RSA with SHA512
         case rs512 = "RS512"
+        /// RSA with SHA256 and PSS padding
+        case ps256 = "PS256" 
+        /// RSA with SHA384 and PSS padding
+        case ps384 = "PS384"
+        /// RSA with SHA512 and PSS padding
+        case ps512 = "PS512"
         /// EC with SHA256
         case es256 = "ES256"
         /// EC with SHA384

--- a/Sources/JWTKit/JWTSigners.swift
+++ b/Sources/JWTKit/JWTSigners.swift
@@ -182,6 +182,12 @@ private struct JWKSigner {
                 return JWTSigner.rs384(key: rsaKey)
             case .rs512:
                 return JWTSigner.rs512(key: rsaKey)
+            case .ps256:
+                return JWTSigner.ps256(key: rsaKey)
+            case .ps384:
+                return JWTSigner.ps384(key: rsaKey)
+            case .ps512:
+                return JWTSigner.ps512(key: rsaKey)
             default:
                 return nil
             }

--- a/Sources/JWTKit/RSA/JWTSigner+RSA.swift
+++ b/Sources/JWTKit/RSA/JWTSigner+RSA.swift
@@ -5,7 +5,8 @@ extension JWTSigner {
         return .init(algorithm: RSASigner(
             key: key,
             algorithm: CJWTKitBoringSSL_EVP_sha256(),
-            name: "RS256"
+            name: "RS256",
+            usePSS: false
         ))
     }
 
@@ -13,7 +14,8 @@ extension JWTSigner {
         return .init(algorithm: RSASigner(
             key: key,
             algorithm: CJWTKitBoringSSL_EVP_sha384(),
-            name: "RS384"
+            name: "RS384",
+            usePSS: false
         ))
     }
 
@@ -21,7 +23,35 @@ extension JWTSigner {
         return .init(algorithm: RSASigner(
             key: key,
             algorithm: CJWTKitBoringSSL_EVP_sha512(),
-            name: "RS512"
+            name: "RS512",
+            usePSS: false
+        ))
+    }
+
+    public static func ps256(key: RSAKey) -> JWTSigner {
+        return .init(algorithm: RSASigner(
+            key: key,
+            algorithm: CJWTKitBoringSSL_EVP_sha256(),
+            name: "PS256",
+            usePSS: true
+        ))
+    }
+
+    public static func ps384(key: RSAKey) -> JWTSigner {
+        return .init(algorithm: RSASigner(
+            key: key,
+            algorithm: CJWTKitBoringSSL_EVP_sha384(),
+            name: "PS384",
+            usePSS: true
+        ))
+    }
+
+    public static func ps512(key: RSAKey) -> JWTSigner {
+        return .init(algorithm: RSASigner(
+            key: key,
+            algorithm: CJWTKitBoringSSL_EVP_sha512(),
+            name: "PS512",
+            usePSS: true
         ))
     }
 }

--- a/Sources/JWTKit/RSA/RSASigner.swift
+++ b/Sources/JWTKit/RSA/RSASigner.swift
@@ -5,6 +5,7 @@ internal struct RSASigner: JWTAlgorithm, OpenSSLSigner {
     let key: RSAKey
     let algorithm: OpaquePointer
     let name: String
+    let usePSS: Bool
 
     func sign<Plaintext>(_ plaintext: Plaintext) throws -> [UInt8]
         where Plaintext: DataProtocol
@@ -12,25 +13,45 @@ internal struct RSASigner: JWTAlgorithm, OpenSSLSigner {
         guard case .private = self.key.type else {
             throw JWTError.signingAlgorithmFailure(RSAError.privateKeyRequired)
         }
-        var signatureLength: UInt32 = 0
+
         var signature = [UInt8](
             repeating: 0,
             count: Int(CJWTKitBoringSSL_RSA_size(key.c))
         )
 
         let digest = try self.digest(plaintext)
-        guard CJWTKitBoringSSL_RSA_sign(
-            CJWTKitBoringSSL_EVP_MD_type(self.algorithm),
-            digest,
-            numericCast(digest.count),
-            &signature,
-            &signatureLength,
-            self.key.c
-        ) == 1 else {
+        let signingResult: Int32
+        let signLen: Int
+        if self.usePSS {
+            var signatureLength: Int = 0
+            signingResult = CJWTKitBoringSSL_RSA_sign_pss_mgf1(
+                self.key.c,
+                &signatureLength,
+                &signature,
+                signature.count,
+                digest,
+                numericCast(digest.count),
+                self.algorithm,
+                nil,
+                -1)
+            signLen = signatureLength
+        } else {
+            var signatureLength: UInt32 = 0
+            signingResult = CJWTKitBoringSSL_RSA_sign(
+                CJWTKitBoringSSL_EVP_MD_type(self.algorithm),
+                digest,
+                numericCast(digest.count),
+                &signature,
+                &signatureLength,
+                self.key.c
+            )
+            signLen = numericCast(signatureLength)
+        }
+        guard signingResult == 1 else {
             throw JWTError.signingAlgorithmFailure(RSAError.signFailure)
         }
 
-        return .init(signature[0..<numericCast(signatureLength)])
+        return .init(signature[0..<numericCast(signLen)])
     }
 
     func verify<Signature, Plaintext>(
@@ -41,13 +62,25 @@ internal struct RSASigner: JWTAlgorithm, OpenSSLSigner {
     {
         let digest = try self.digest(plaintext)
         let signature = signature.copyBytes()
-        return CJWTKitBoringSSL_RSA_verify(
-            CJWTKitBoringSSL_EVP_MD_type(self.algorithm),
-            digest,
-            numericCast(digest.count),
-            signature,
-            numericCast(signature.count),
-            self.key.c
-        ) == 1
+        if self.usePSS {
+            return CJWTKitBoringSSL_RSA_verify_pss_mgf1(
+                self.key.c,
+                digest,
+                digest.count,
+                self.algorithm,
+                nil,
+                -1,
+                signature,
+                signature.count) == 1
+        } else {
+            return CJWTKitBoringSSL_RSA_verify(
+                CJWTKitBoringSSL_EVP_MD_type(self.algorithm),
+                digest,
+                numericCast(digest.count),
+                signature,
+                numericCast(signature.count),
+                self.key.c
+            ) == 1
+        }
     }
 }


### PR DESCRIPTION
Hi all

This pull request adds the support to `PS256`, `PS384` and `PS512` algorithms to this already wonderful jws library.

It doesn't have any impact on the public APIs. It just adds 3 new `JWTSigners` and it gives support for the 3 algorithms in the `JWKSigner` out of the box.

For the cryptographic part, it relies on `BoringSSL` existing functions

We also have added tests to verify the correct implementation

