### PR TITLE
Add option to use a custom JSONDecoder for each JWTPayload type

### DIFF
--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -19,14 +19,17 @@ struct JWTParser {
     }
 
     func header() throws -> JWTHeader {
-        try self.jsonDecoder()
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .secondsSince1970
+        
+        return try jsonDecoder
             .decode(JWTHeader.self, from: .init(self.encodedHeader.base64URLDecodedBytes()))
     }
 
     func payload<Payload>(as payload: Payload.Type) throws -> Payload
         where Payload: JWTPayload
     {
-        try self.jsonDecoder()
+        try payload.jsonDecoder()
             .decode(Payload.self, from: .init(self.encodedPayload.base64URLDecodedBytes()))
     }
 
@@ -42,11 +45,5 @@ struct JWTParser {
 
     private var message: ArraySlice<UInt8> {
         self.encodedHeader + [.period] + self.encodedPayload
-    }
-
-    private func jsonDecoder() -> JSONDecoder {
-        let jsonDecoder = JSONDecoder()
-        jsonDecoder.dateDecodingStrategy = .secondsSince1970
-        return jsonDecoder
     }
 }

--- a/Sources/JWTKit/JWTPayload.swift
+++ b/Sources/JWTKit/JWTPayload.swift
@@ -1,6 +1,21 @@
+import Foundation
+
 /// A JWT payload is a Publically Readable set of claims
 /// Each variable represents a claim.
 public protocol JWTPayload: Codable {
     /// Verifies that the payload's claims are correct or throws an error.
     func verify(using signer: JWTSigner) throws
+    
+    /// JSONDecoder that is used to decode the JWTPayload Data
+    /// Override this in order to use a custom JSONDecoder for JWTPayload decoding
+    /// This is especially usefuly when wanting to customize the `dateDecodingStrategy` for example
+    static func jsonDecoder() -> JSONDecoder
+}
+
+extension JWTPayload {
+    public static func jsonDecoder() -> JSONDecoder {
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .secondsSince1970
+        return jsonDecoder
+    }
 }

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -815,6 +815,34 @@ class JWTKitTests: XCTestCase {
         let foo = try signers.verify(jwt, as: Foo.self)
         XCTAssertEqual(foo.bar, 42)
     }
+    
+    func testCustomJWTDecoder() throws
+    {
+        struct Payload: JWTPayload {
+            func verify(using signer: JWTKit.JWTSigner) throws {
+                return
+            }
+            
+            static func jsonDecoder() -> JSONDecoder {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .millisecondsSince1970
+                return decoder
+            }
+            
+            var date: Date
+        }
+        
+        let someDate = Date(timeIntervalSince1970: 1681988782.123)
+        let raw = "eyJhbGciOiJIUzI1NiJ9.eyJkYXRlIjoxNjgxOTg4NzgyMTIzfQ._Ff9lojDxfJyA6tkzxALXIl-ldNQpDDuOLEaXJxWhYU"
+        
+        let parser = try JWTParser(token: raw.data(using: .utf8)!)
+        
+        let parsed = try parser.payload(as: Payload.self)
+        
+        let interval = parsed.date.timeIntervalSince(someDate)
+        
+        XCTAssertLessThan(abs(interval), 0.001)
+    }
 
 }
 


### PR DESCRIPTION
Introducing the `jsonDecoder()` static method for `JWTPayload`, which in turn gets used by `JWTParser` when decoding the payload.

This is needed because Apple StoreKit JWT payload dates are encoded in `millisecondsSince1970` format for example. See documentation of [JWSTransactionDecodedPayload](https://developer.apple.com/documentation/appstoreservernotifications/jwstransactiondecodedpayload) for example. 

The implementation that I have chosen is a non-breaking change as I have created a default implementation of the `jsonDecoder()` method in an extension of `JWTPayload`.