### PR TITLE
Increase permitted range for crypto-kit dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         MANGLE_END */
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "4.0.0")
     ],
     targets: [
         .target(name: "CJWTKitBoringSSL"),


### PR DESCRIPTION
Currently the crypto-kit package has a permitted version range of `2.0.0 ..< 3.0.0`. With the release of crypto-kit `3.0.0`, this range is preventing Vapor apps from making use of the latest versions. Increasing the range to `2.0.0 ..< 4.0.0` allows apps to use the latest release without forcing an update.
