### PR TITLE
Fix typo for `JWTError.signatureVerificationFailed` case

### DIFF
--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -4,7 +4,7 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
     case claimVerificationFailure(name: String, reason: String)
     case signingAlgorithmFailure(Error)
     case malformedToken
-    case signatureVerifictionFailed
+    case signatureVerificationFailed
     case missingKIDHeader
     case unknownKID(JWKIdentifier)
     case invalidJWK
@@ -19,7 +19,7 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
             return "signing algorithm error: \(error)"
         case .malformedToken:
             return "malformed JWT"
-        case .signatureVerifictionFailed:
+        case .signatureVerificationFailed:
             return "signature verification failed"
         case .missingKIDHeader:
             return "missing kid field in header"
@@ -41,4 +41,9 @@ public enum JWTError: Error, CustomStringConvertible, LocalizedError {
     public var errorDescription: String? {
         return self.description
     }
+}
+
+extension JWTError {
+    @available(*, deprecated, renamed: "signatureVerificationFailed")
+    public var signatureVerifictionFailed: JWTError { .signatureVerificationFailed }
 }

--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -32,7 +32,7 @@ struct JWTParser {
 
     func verify(using signer: JWTSigner) throws {
         guard try signer.algorithm.verify(self.signature, signs: self.message) else {
-            throw JWTError.signatureVerifictionFailed
+            throw JWTError.signatureVerificationFailed
         }
     }
 

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -427,7 +427,7 @@ class JWTKitTests: XCTestCase {
             _ = try publicSigner.verify(corruptedToken, as: JWTioPayload.self)
         } catch let error as JWTError {
             switch error {
-            case .signatureVerifictionFailed:
+            case .signatureVerificationFailed:
                 // pass
                 XCTAssert(true)
             default:


### PR DESCRIPTION
Succeeds #61 cause I had to re-fork in order to do further edits. Hope that's alright.