### PR TITLE
Add RSA pre-generated token test

### DIFF
--- a/Tests/JWTKitTests/RSATests.swift
+++ b/Tests/JWTKitTests/RSATests.swift
@@ -99,6 +99,24 @@ final class RSATests: XCTestCase {
         await XCTAssertThrowsErrorAsync(try await JWTKeyCollection().addRS256(key: .private(pem: _512BytesKey)))
     }
 
+    func testRS256Verification() async throws {
+        let token = """
+        eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ2YXBvciIsIm5hbWUiOiJmb28iLCJhZG1pbiI6dHJ1ZSwiZXhwIjoyMDAwMDAwMDAwfQ.JZ3uuzojbqbkZBoCKOrjzu4ICNjFt_H4XNqO4I8sM8PRmxzg-_kY2_MhVJkKga30afWp00z5FNoT14CsdKXWKEaWCwXgYTatLQI3yt77aqj7-RC_eBCl6qRDnPH7Aq5KkBNGsoMwUAWKeHB7ZHZulqqqaeRUyEIXmUJiyUy7TjZyVhk1WsXANGxDWvutsVG6dmiFhaSWqj1RsmyWqbuDoyd3uIHzyHy4mx1Y-nwxMofoS0k-SkyZcEPVJ2Am99VZ4rwSJbH2QcmaZr5o1rS8sJiReVYfyEF2YghN9tLj3FF11scgtpjDMzcIkbsIntclaYmU1b7GlIFB6897sdjJpA
+        """
+        let testPayload = TestPayload(
+            sub: "vapor",
+            name: "foo",
+            admin: true,
+            exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+        )
+        let keyCollection = try await JWTKeyCollection()
+            .addRS256(key: .private(pem: privateKey2), kid: "private")
+            .addRS256(key: .public(pem: publicKey2), kid: "public")
+
+        let payload = try await keyCollection.verify(token, as: TestPayload.self)
+        XCTAssertEqual(payload, testPayload)
+    }
+
     // MARK: Private functions
 
     private func testModularInverse(_ testGroup: TestGroup) throws {
@@ -248,6 +266,49 @@ MHPVpBn+DE092fvU2cRHhmbJFJaRPARxsonNeFwczJPOuseNSbjA65K4Bqlm9ywv
 la4Op9AHh7N6hiTGJwn6MyxfxFm8+2wATNX3BglUXwiPtfMwGnNy4ft5Nxi6ZI7m
 QkJUDkYq0ZsPjk6/4fYP1abrsDcWua0BrYtzBZqLVWKQWJ0xftGmX2m6
 -----END CERTIFICATE-----
+"""
+
+let privateKey2 = """
+-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC7VJTUt9Us8cKj
+MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu
+NMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ
+qgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulg
+p2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR
+ZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwi
+VuNd9tybAgMBAAECggEBAKTmjaS6tkK8BlPXClTQ2vpz/N6uxDeS35mXpqasqskV
+laAidgg/sWqpjXDbXr93otIMLlWsM+X0CqMDgSXKejLS2jx4GDjI1ZTXg++0AMJ8
+sJ74pWzVDOfmCEQ/7wXs3+cbnXhKriO8Z036q92Qc1+N87SI38nkGa0ABH9CN83H
+mQqt4fB7UdHzuIRe/me2PGhIq5ZBzj6h3BpoPGzEP+x3l9YmK8t/1cN0pqI+dQwY
+dgfGjackLu/2qH80MCF7IyQaseZUOJyKrCLtSD/Iixv/hzDEUPfOCjFDgTpzf3cw
+ta8+oE4wHCo1iI1/4TlPkwmXx4qSXtmw4aQPz7IDQvECgYEA8KNThCO2gsC2I9PQ
+DM/8Cw0O983WCDY+oi+7JPiNAJwv5DYBqEZB1QYdj06YD16XlC/HAZMsMku1na2T
+N0driwenQQWzoev3g2S7gRDoS/FCJSI3jJ+kjgtaA7Qmzlgk1TxODN+G1H91HW7t
+0l7VnL27IWyYo2qRRK3jzxqUiPUCgYEAx0oQs2reBQGMVZnApD1jeq7n4MvNLcPv
+t8b/eU9iUv6Y4Mj0Suo/AU8lYZXm8ubbqAlwz2VSVunD2tOplHyMUrtCtObAfVDU
+AhCndKaA9gApgfb3xw1IKbuQ1u4IF1FJl3VtumfQn//LiH1B3rXhcdyo3/vIttEk
+48RakUKClU8CgYEAzV7W3COOlDDcQd935DdtKBFRAPRPAlspQUnzMi5eSHMD/ISL
+DY5IiQHbIH83D4bvXq0X7qQoSBSNP7Dvv3HYuqMhf0DaegrlBuJllFVVq9qPVRnK
+xt1Il2HgxOBvbhOT+9in1BzA+YJ99UzC85O0Qz06A+CmtHEy4aZ2kj5hHjECgYEA
+mNS4+A8Fkss8Js1RieK2LniBxMgmYml3pfVLKGnzmng7H2+cwPLhPIzIuwytXywh
+2bzbsYEfYx3EoEVgMEpPhoarQnYPukrJO4gwE2o5Te6T5mJSZGlQJQj9q4ZB2Dfz
+et6INsK0oG8XVGXSpQvQh3RUYekCZQkBBFcpqWpbIEsCgYAnM3DQf3FJoSnXaMhr
+VBIovic5l0xFkEHskAjFTevO86Fsz1C2aSeRKSqGFoOQ0tmJzBEs1R6KqnHInicD
+TQrKhArgLXX4v3CddjfTRJkFWDbE/CkvKZNOrcf1nhaGCPspRJj2KUkj1Fhl9Cnc
+dn/RsYEONbwQSjIfMPkvxF+8HQ==
+-----END PRIVATE KEY-----
+"""
+
+let publicKey2 = """
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
++qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ
+0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg
+cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc
+mwIDAQAB
+-----END PUBLIC KEY-----
 """
 
 struct GCDTestVector: Codable {


### PR DESCRIPTION
This adds a test to the RSA suite which tests RS256 verification using a token generated on jwt.io. After #112 was opened, it was weird that all tests were passing even though the padding was changed, that was because all tests were both signing verifying (without giving verification a chance to use tokens from the outside), and therefore using PSS (which is PS256, not RS256). This adds a test to avoid this mistake in the future

This test is correctly going to fail while that PR is unmerged, as the token was generated using `insecurePKCS1v1_5` padding but verification uses `PSS`

Also, thanks to @MFranceschi6 for spotting this!