### PR TITLE
Add option to sign tokens with x5c chains

### DIFF
--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -14,6 +14,7 @@ public struct JWTError: Error, @unchecked Sendable {
             case invalidJWK
             case invalidBool
             case noKeyProvided
+            case invalidX5CChain
             case generic
         }
 
@@ -32,6 +33,7 @@ public struct JWTError: Error, @unchecked Sendable {
         package static let invalidJWK = Self(.invalidJWK)
         package static let invalidBool = Self(.invalidBool)
         package static let noKeyProvided = Self(.noKeyProvided)
+        package static let invalidX5CChain = Self(.invalidX5CChain)
         package static let generic = Self(.generic)
 
         public var description: String {
@@ -54,6 +56,8 @@ public struct JWTError: Error, @unchecked Sendable {
                 "invalidBool"
             case .noKeyProvided:
                 "noKeyProvided"
+            case .invalidX5CChain:
+                "invalidX5CChain"
             case .generic:
                 "generic"
             }
@@ -149,6 +153,12 @@ public struct JWTError: Error, @unchecked Sendable {
     }
 
     public static let noKeyProvided = Self(errorType: .noKeyProvided)
+
+    public static func invalidX5CChain(reason: String) -> Self {
+        var new = Self(errorType: .invalidX5CChain)
+        new.reason = reason
+        return new
+    }
 
     public static func generic(identifier: String, reason: String) -> Self {
         var new = Self(errorType: .generic)

--- a/Sources/JWTKit/JWTKeyCollection.swift
+++ b/Sources/JWTKit/JWTKeyCollection.swift
@@ -228,9 +228,10 @@ public actor JWTKeyCollection: Sendable {
     public func sign(
         _ payload: some JWTPayload,
         typ: String = "JWT",
-        kid: JWKIdentifier? = nil
-    ) throws -> String {
+        kid: JWKIdentifier? = nil,
+        x5c: [String]? = nil
+    ) async throws -> String {
         let signer = try self.getSigner(for: kid)
-        return try signer.sign(payload, typ: typ, kid: kid)
+        return try await signer.sign(payload, typ: typ, kid: kid, x5c: x5c)
     }
 }

--- a/Sources/JWTKit/JWTSerializer.swift
+++ b/Sources/JWTKit/JWTSerializer.swift
@@ -1,3 +1,6 @@
+import Foundation
+import X509
+
 struct JWTSerializer {
     func sign(
         _ payload: some JWTPayload,
@@ -5,14 +8,24 @@ struct JWTSerializer {
         typ: String = "JWT",
         kid: JWKIdentifier? = nil,
         cty: String? = nil,
+        x5c: [String]? = nil,
         jsonEncoder: any JWTJSONEncoder
-    ) throws -> String {
+    ) async throws -> String {
         // encode header, copying header struct to mutate alg
         var header = JWTHeader()
         header.kid = kid
         header.typ = typ
         header.cty = cty
         header.alg = signer.algorithm.name
+
+        if let x5c, !x5c.isEmpty {
+            let verifier = try X5CVerifier(rootCertificates: [x5c[0]])
+            try await verifier.verifyChain(certificates: x5c)
+            header.x5c = try x5c.map {
+                let certificate = try Certificate(pemEncoded: $0)
+                return try Data(certificate.serializeAsPEM().derBytes).base64EncodedString()
+            }
+        }
 
         let headerData = try jsonEncoder.encode(header)
         let encodedHeader = headerData.base64URLEncodedBytes()

--- a/Sources/JWTKit/JWTSigner.swift
+++ b/Sources/JWTKit/JWTSigner.swift
@@ -21,9 +21,10 @@ final class JWTSigner: Sendable {
         _ payload: some JWTPayload,
         typ: String = "JWT",
         kid: JWKIdentifier? = nil,
-        cty: String? = nil
-    ) throws -> String {
-        try JWTSerializer().sign(payload, using: self, typ: typ, kid: kid, cty: cty, jsonEncoder: self.jsonEncoder ?? .defaultForJWT)
+        cty: String? = nil,
+        x5c: [String]? = nil
+    ) async throws -> String {
+        try await JWTSerializer().sign(payload, using: self, typ: typ, kid: kid, cty: cty, x5c: x5c, jsonEncoder: self.jsonEncoder ?? .defaultForJWT)
     }
 
     func unverified<Payload>(

--- a/Sources/JWTKit/X5C/X5CVerifier.swift
+++ b/Sources/JWTKit/X5C/X5CVerifier.swift
@@ -22,7 +22,7 @@ public struct X5CVerifier: Sendable {
     /// - Parameter rootCertificates: The root certificates to be trusted.
     public init(rootCertificates: [String]) throws {
         guard !rootCertificates.isEmpty else {
-            throw JWTError.generic(identifier: "JWS", reason: "No root certs provided")
+            throw JWTError.invalidX5CChain(reason: "No root certificates provided")
         }
         trustedStore = try X509.CertificateStore(rootCertificates.map {
             try X509.Certificate(pemEncoded: $0)
@@ -36,6 +36,24 @@ public struct X5CVerifier: Sendable {
         try self.init(rootCertificates: rootCertificates.map {
             String(decoding: $0, as: UTF8.self)
         })
+    }
+
+    /// Verify a chain of certificates against the trusted root certificates.
+    ///
+    /// - Parameter certificates: The certificates to verify.
+    /// - Throws: A `JWTError` if the chain is invalid.
+    package func verifyChain(certificates: [String]) async throws {
+        let certificates = try certificates.map {
+            try Certificate(pemEncoded: $0)
+        }
+        let untrustedChain = CertificateStore(certificates)
+        var verifier = Verifier(rootCertificates: trustedStore) {
+            RFC5280Policy(validationTime: Date())
+        }
+        let result = await verifier.validate(leafCertificate: certificates[0], intermediates: untrustedChain)
+        if case let .couldNotValidate(failures) = result {
+            throw JWTError.invalidX5CChain(reason: "\(failures)")
+        }
     }
 
     /// Verify a JWS with the `x5c` header parameter against the trusted root
@@ -105,26 +123,28 @@ public struct X5CVerifier: Sendable {
 
         // Ensure the algorithm used is ES256, as it's the only supported one (for now)
         guard let headerAlg = header.alg, headerAlg == "ES256" else {
-            throw JWTError.generic(identifier: "JWS", reason: "Only ES256 is currently supported")
+            throw JWTError.invalidX5CChain(reason: "Unsupported algorithm: \(header.alg ?? "nil")")
         }
 
         // Ensure the x5c header parameter is present and not empty
         guard let x5c = header.x5c, !x5c.isEmpty else {
-            throw JWTError.generic(identifier: "JWS", reason: "No x5c certificates provided")
+            throw JWTError.invalidX5CChain(reason: "Missing or empty x5c header parameter")
         }
 
         // Decode the x5c certificates
         let certificateData = try x5c.map {
             guard let data = Data(base64Encoded: $0) else {
-                throw JWTError.generic(identifier: "JWS", reason: "Invalid x5c certificate")
+                throw JWTError.invalidX5CChain(reason: "Invalid x5c certificate: \($0)")
             }
             return data
         }
 
-        // Setup an untrusted chain using all the certificates in the x5c
-        let untrustedChain = try CertificateStore(certificateData.map {
+        let certificates = try certificateData.map {
             try Certificate(derEncoded: [UInt8]($0))
-        })
+        }
+
+        // Setup an untrusted chain using all the certificates in the x5c
+        let untrustedChain = CertificateStore(certificates)
 
         let payload = try parser.payload(as: Payload.self, jsonDecoder: jsonDecoder)
 
@@ -142,18 +162,15 @@ public struct X5CVerifier: Sendable {
             RFC5280Policy(validationTime: date)
         }
 
-        // Extract the leaf certificate (first certificate in x5c)
-        let leafCertificate = try Certificate(derEncoded: [UInt8](certificateData[0]))
-
         // Validate the leaf certificate against the trusted store
-        let result = await verifier.validate(leafCertificate: leafCertificate, intermediates: untrustedChain)
+        let result = await verifier.validate(leafCertificate: certificates[0], intermediates: untrustedChain)
 
         if case let .couldNotValidate(failures) = result {
-            throw JWTError.generic(identifier: "JWS", reason: "Invalid x5c chain: \(failures)")
+            throw JWTError.invalidX5CChain(reason: "\(failures)")
         }
 
         // Assuming the chain is valid, verify the token was signed by the valid certificate
-        let ecdsaKey = try ES256Key.certificate(pem: leafCertificate.serializeAsPEM().pemString)
+        let ecdsaKey = try ES256Key.certificate(pem: certificates[0].serializeAsPEM().pemString)
 
         let signer = JWTSigner(algorithm: ECDSASigner(key: ecdsaKey, algorithm: .sha256, name: headerAlg))
         return try await signer.verify(parser: parser)

--- a/Tests/JWTKitTests/X5CTests.swift
+++ b/Tests/JWTKitTests/X5CTests.swift
@@ -190,6 +190,30 @@ final class X5CTests: XCTestCase {
         await XCTAssertNoThrowAsync(try await verifier.verifyJWS(token, as: TestPayload.self))
     }
 
+    func testSigningWithInvalidX5CChain() async throws {
+        let keyCollection = try await JWTKeyCollection().addES256(key: .private(pem: x5cLeafCertKey))
+
+        let payload = TestPayload(
+            sub: "vapor",
+            name: "Foo",
+            admin: false,
+            exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+        )
+
+        // Remove the intermediate cert from the chain
+        let certs = x5cCerts.enumerated().filter { $0.offset != 1 }.map { $0.element }
+
+        let token = try await keyCollection.sign(payload, x5c: certs)
+        let parser = try JWTParser(token: token.bytes)
+        try await parser.verify(using: keyCollection.getKey())
+
+        let x5c = try XCTUnwrap(parser.header().x5c)
+        let pemCerts = try x5c.map(getPEMString)
+        XCTAssertEqual(pemCerts, certs)
+        let verifier = try X5CVerifier(rootCertificates: [certs.last!])
+        await XCTAssertThrowsErrorAsync(try await verifier.verifyJWS(token, as: TestPayload.self))
+    }
+
     private func getPEMString(from der: String) throws -> String {
         var encoded = der[...]
         let pemLineCount = (encoded.utf8.count + 64) / 64

--- a/Tests/JWTKitTests/X5CTests.swift
+++ b/Tests/JWTKitTests/X5CTests.swift
@@ -1,5 +1,6 @@
-import XCTest
 import JWTKit
+import X509
+import XCTest
 
 /// Test the x5c verification abilities of JWTSigners.
 ///
@@ -165,6 +166,48 @@ final class X5CTests: XCTestCase {
         XCTAssertEqual(data.appAppleId, 1234)
         XCTAssertEqual(data.environment, "Sandbox")
     }
+
+    func testSigningWithX5CChain() async throws {
+        let keyCollection = try await JWTKeyCollection().addES256(key: .private(pem: x5cLeafCertKey))
+
+        let payload = TestPayload(
+            sub: "vapor",
+            name: "Foo",
+            admin: false,
+            exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+        )
+        let token = try await keyCollection.sign(payload, x5c: x5cCerts)
+        let parser = try JWTParser(token: token.bytes)
+        try XCTAssertEqual(parser.header().typ, "JWT")
+        try XCTAssertEqual(parser.header().alg, "ES256")
+        try XCTAssertEqual(parser.payload(as: TestPayload.self), payload)
+        try await parser.verify(using: keyCollection.getKey())
+
+        let x5c = try XCTUnwrap(parser.header().x5c)
+        let pemCerts = try x5c.map(getPEMString)
+        XCTAssertEqual(pemCerts, x5cCerts)
+        let verifier = try X5CVerifier(rootCertificates: [x5cCerts.last!])
+        await XCTAssertNoThrowAsync(try await verifier.verifyJWS(token, as: TestPayload.self))
+    }
+
+    private func getPEMString(from der: String) throws -> String {
+        var encoded = der[...]
+        let pemLineCount = (encoded.utf8.count + 64) / 64
+        var pemLines = [Substring]()
+        pemLines.reserveCapacity(pemLineCount + 2)
+
+        pemLines.append("-----BEGIN CERTIFICATE-----")
+
+        while encoded.count > 0 {
+            let prefixIndex = encoded.index(encoded.startIndex, offsetBy: 64, limitedBy: encoded.endIndex) ?? encoded.endIndex
+            pemLines.append(encoded[..<prefixIndex])
+            encoded = encoded[prefixIndex...]
+        }
+
+        pemLines.append("-----END CERTIFICATE-----")
+
+        return pemLines.joined(separator: "\n")
+    }
 }
 
 let validToken = """
@@ -197,6 +240,60 @@ eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsIng1YyI6WyJNSUlCbHpDQ0FUMENGQmdtUFlSaE1nY0VQ
 
 let validButNotCoolToken = """
 eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsIng1YyI6WyJNSUlCanpDQ0FUVUNGSDhFWFBJbDBRbDQwYzdKOEhkK2R6QWgwY3dVTUFvR0NDcUdTTTQ5QkFNQ01FNHhDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1RNHdEQVlEVlFRS0RBVldZWEJ2Y2pFYU1CZ0dBMVVFQXd3UmFXNTBaWEp0WldScFlYUmxMV05sY25Rd0hoY05Nak14TURJME1UTTBNalU1V2hjTk1qUXhNREl6TVRNME1qVTVXakJHTVFzd0NRWURWUVFHRXdKVlV6RVRNQkVHQTFVRUNBd0tVMjl0WlMxVGRHRjBaVEVPTUF3R0ExVUVDZ3dGVm1Gd2IzSXhFakFRQmdOVkJBTU1DV3hsWVdZdFkyVnlkREJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUFCRU85VjZLQWhSR0l4QWx2Ukl6U3BtSVRmVVZiWHl5ZGMvZWdlbHpLLzZ3NDEySmc4RDJlSVRkOHVDRmxnVmh4WUlkR1pNN1hYUWhaNmhOZnE2S3JyUG93Q2dZSUtvWkl6ajBFQXdJRFNBQXdSUUloQUxJaXhudE93V3o4NlFHa0g0SGNnT09malBiczlBUVpXYm1HYkpKRjRWRWZBaUI4ZUVLRi9WQllvWVhRREQzVHpLNUlEMkdzbXplMzhpNk56ek9ndHRMam9nPT0iLCJNSUlCNXpDQ0FZeWdBd0lCQWdJVUw2ZnJzdHdldjdZTWtPWVNuUHVlSlQyR3g1UXdDZ1lJS29aSXpqMEVBd0l3UmpFTE1Ba0dBMVVFQmhNQ1ZWTXhFekFSQmdOVkJBZ01DbE52YldVdFUzUmhkR1V4RGpBTUJnTlZCQW9NQlZaaGNHOXlNUkl3RUFZRFZRUUREQWx5YjI5MExXTmxjblF3SGhjTk1qTXhNREkwTVRNME1qTTFXaGNOTWpneE1ESXlNVE0wTWpNMVdqQk9NUXN3Q1FZRFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0F3S1UyOXRaUzFUZEdGMFpURU9NQXdHQTFVRUNnd0ZWbUZ3YjNJeEdqQVlCZ05WQkFNTUVXbHVkR1Z5YldWa2FXRjBaUzFqWlhKME1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRWt6WGFFQTlDSVpyUkVmQ0Mra05tM0pxZDdmR0ZFT05Ia2p5TFJ4NS83SUFYeHB4TGZ0WWNoOTU1K1VRNVhHOHdUZ2tNQ0NaNG9LRjhNMXg3Zkw3cXU2TlFNRTR3REFZRFZSMFRCQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVyRU53VW02VDBSbmUxTW9MY3lWQ2NhVTVvTTB3SHdZRFZSMGpCQmd3Rm9BVVkxM3oxRVhHbjlVQmZwZ3BmVTl0UWJ2TVJRZ3dDZ1lJS29aSXpqMEVBd0lEU1FBd1JnSWhBSW04bStLb0RFbktBdUgrZUZROGJWSDJkc3p2NlcveCtwNE9zZERzd0VrNUFpRUF5bWd1SmdxQUpZU3NDdzdYM0pDVVBNY29LdGFRRzZNamhRdThrWlpCQUNJPSIsIk1JSUI0VENDQVllZ0F3SUJBZ0lVRG9PZWZlZkNOcS9UR1dyaUlzWUh2ejBMcE5Jd0NnWUlLb1pJemowRUF3SXdSakVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNsTnZiV1V0VTNSaGRHVXhEakFNQmdOVkJBb01CVlpoY0c5eU1SSXdFQVlEVlFRRERBbHliMjkwTFdObGNuUXdIaGNOTWpNeE1ESTBNVEl3T0RJM1doY05Nek14TURJeE1USXdPREkzV2pCR01Rc3dDUVlEVlFRR0V3SlZVekVUTUJFR0ExVUVDQXdLVTI5dFpTMVRkR0YwWlRFT01Bd0dBMVVFQ2d3RlZtRndiM0l4RWpBUUJnTlZCQU1NQ1hKdmIzUXRZMlZ5ZERCWk1CTUdCeXFHU000OUFnRUdDQ3FHU000OUF3RUhBMElBQk5wditIRzUyak9UMVcrcjFrMTNiSm8yazlEeVJ5RmJ5Y0JwUHNXUUtmdDlueHdFSHZ6RGoxaXZvTWZhanhsTCtuL0ZMQm5Pblk2M21GV216YW9adkgralV6QlJNQjBHQTFVZERnUVdCQlJqWGZQVVJjYWYxUUYrbUNsOVQyMUJ1OHhGQ0RBZkJnTlZIU01FR0RBV2dCUmpYZlBVUmNhZjFRRittQ2w5VDIxQnU4eEZDREFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQW9HQ0NxR1NNNDlCQU1DQTBnQU1FVUNJR0lwWDlsbGlVMTM1VjgrTFk2L2NqQm1HcktLTmxZV0xMb1o2RGlhdXpkSkFpRUE5R1NBSUdoZk05a2JXbGtjak1zNmxBNHB3ZjRSZlVFRmVnaFlwWkticUZvPSJdfQ.eyJjb29sIjpmYWxzZX0.JtNl3uCSJ7rycwW__0o1xARr0y5XYsXUc2Ltx1W2IKmBmn66vAOEY2Eur9Xy40eX8qMr8GrxsGmzia5YEN3ugQ
+"""
+
+let x5cCerts = [
+    """
+    -----BEGIN CERTIFICATE-----
+    MIIBpDCCAUkCFHVcsASQJGJi6BI+7apcSVrcWaAAMAoGCCqGSM49BAMCMFMxCzAJ
+    BgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5l
+    dCBXaWRnaXRzIFB0eSBMdGQxDDAKBgNVBAMMA1llczAeFw0yMzExMjMyMTQwNDha
+    Fw0yNDExMjIyMTQwNDhaMFUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0
+    YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxDjAMBgNVBAMM
+    BU1heWJlMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEORJB5yvqxuG7+EgBDUK/
+    BjjE1SFU2w+EZkhhLDUmnXdujwuVvNuoEAhXXpKXJA0lMXUL3VpYkjfPokElxKow
+    yjAKBggqhkjOPQQDAgNJADBGAiEAs11xN77nyLwfnLupy957CdUQZwEj5kfGD/UA
+    deOvPx8CIQDD0BAEP10e3SdkQYBLtvmIfR8LEtf1FN9LpeRFjMsd0Q==
+    -----END CERTIFICATE-----
+    """,
+    """
+    -----BEGIN CERTIFICATE-----
+    MIIB9zCCAZ2gAwIBAgIURyU7Zx4xpWe/qgQ/o5WWDKO1QAkwCgYIKoZIzj0EAwIw
+    UjELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGElu
+    dGVybmV0IFdpZGdpdHMgUHR5IEx0ZDELMAkGA1UEAwwCTm8wHhcNMjMxMTIzMjE0
+    MDM4WhcNMjgxMTIxMjE0MDM4WjBTMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29t
+    ZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMQwwCgYD
+    VQQDDANZZXMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQtXAr2JmHbVbVcCOsE
+    C2HVYbZjj9jNJHSDRRJPo/pRjx6INrcO6ff2SLh+Y0pTy9ztSP0JkK8sOmx1MGDU
+    VS8uo1AwTjAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBR91V3hyIdfdXR/k49UAauW
+    M7MsuzAfBgNVHSMEGDAWgBQKOxtgWctssvjCMrI3s5ifF6rpojAKBggqhkjOPQQD
+    AgNIADBFAiEAphZb4dN19p+UBVMe1UgMVORQ6I14Z96/F+17umwDgfACIF9lGumM
+    Fr8KVqiSUvfHyaaqXGrrP9dExVLSqcAaPyPr
+    -----END CERTIFICATE-----
+    """,
+    """
+    -----BEGIN CERTIFICATE-----
+    MIIB+jCCAZ+gAwIBAgIUDSttzLVHb8h1sQTQTSN6hrR2oSUwCgYIKoZIzj0EAwIw
+    UjELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGElu
+    dGVybmV0IFdpZGdpdHMgUHR5IEx0ZDELMAkGA1UEAwwCTm8wHhcNMjMxMTIzMjE0
+    MDM0WhcNMzMxMTIwMjE0MDM0WjBSMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29t
+    ZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMQswCQYD
+    VQQDDAJObzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABBdNKGGwi8EOZL+yEuBM
+    n0+L0cHiUxBvUW6BkXkLwP0YgkSQ5S3rPplsGp+U7SotTHl9pqsPW2ErnA7V12zU
+    E1WjUzBRMB0GA1UdDgQWBBQKOxtgWctssvjCMrI3s5ifF6rpojAfBgNVHSMEGDAW
+    gBQKOxtgWctssvjCMrI3s5ifF6rpojAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49
+    BAMCA0kAMEYCIQCf4tM5SmcWmN6/7zNfjfLV1N3IBTO68cub3PpYurQUKAIhALwO
+    oqoVTtJyc2qmFL/EYTcXZU8VwpBJOtQVxjxPI+8s
+    -----END CERTIFICATE-----
+    """,
+]
+
+let x5cLeafCertKey = """
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICqzgINLJICNbFxXI9rYvKGL3g1bCJTjQGIIz9AvfRjBoAoGCCqGSM49
+AwEHoUQDQgAEORJB5yvqxuG7+EgBDUK/BjjE1SFU2w+EZkhhLDUmnXdujwuVvNuo
+EAhXXpKXJA0lMXUL3VpYkjfPokElxKowyg==
+-----END EC PRIVATE KEY-----
 """
 
 /// Each token has the following payload:


### PR DESCRIPTION
This adds a new `x5c` parameter to the sign method, which accepts an array of pem encoded certificates which form an x5c chain. This chain gets added to the JWT's header with the `x5c` field. For the token to be valid, it must be signed with the leaf certificate's private key