### PR TITLE
Add RSA size boundary

### DIFF
--- a/Tests/JWTKitTests/RSATests.swift
+++ b/Tests/JWTKitTests/RSATests.swift
@@ -24,14 +24,14 @@ final class RSATests: XCTestCase {
 
     func testPublicKeyInitializationFromCryptoKey() throws {
         let cryptoKey = try _RSA.Signing.PublicKey(pemRepresentation: publicKey)
-        let jwtKey = Insecure.RSA.PublicKey(backing: cryptoKey)
+        let jwtKey = try Insecure.RSA.PublicKey(backing: cryptoKey)
         let otherKey = try Insecure.RSA.PublicKey(pem: publicKey)
         XCTAssertEqual(jwtKey, otherKey)
     }
 
     func testPrivateKeyInitializationFromCryptoKey() throws {
         let cryptoKey = try _RSA.Signing.PrivateKey(pemRepresentation: privateKey)
-        let jwtKey = Insecure.RSA.PrivateKey(backing: cryptoKey)
+        let jwtKey = try Insecure.RSA.PrivateKey(backing: cryptoKey)
         let otherKey = try Insecure.RSA.PrivateKey(pem: privateKey)
         XCTAssertEqual(jwtKey, otherKey)
     }


### PR DESCRIPTION
This adds the 2048 bit RSA key size lower boundary as of RFC 7518 section  [3.3](https://datatracker.ietf.org/doc/html/rfc7518#section-3.3) and [3.5](https://datatracker.ietf.org/doc/html/rfc7518#section-3.5)