### PR TITLE
Add `kid` param to sign function

### DIFF
--- a/Sources/JWTKit/JWTKeyCollection.swift
+++ b/Sources/JWTKit/JWTKeyCollection.swift
@@ -233,7 +233,7 @@ public actor JWTKeyCollection: Sendable {
             updatedHeader.kid = effectiveKidValue
         }
 
-        let signer = try self.getSigner(for: kid, alg: header.alg)
-        return try await signer.sign(payload, with: header)
+        let signer = try self.getSigner(for: effectiveKid, alg: updatedHeader.alg)
+        return try await signer.sign(payload, with: updatedHeader)
     }
 }

--- a/Sources/JWTKit/JWTKeyCollection.swift
+++ b/Sources/JWTKit/JWTKeyCollection.swift
@@ -12,7 +12,7 @@ public actor JWTKeyCollection: Sendable {
 
     private var storage: [JWKIdentifier: Signer]
     private var `default`: Signer?
-    
+
     public let defaultJWTParser: any JWTParser
     public let defaultJWTSerializer: any JWTSerializer
 
@@ -213,17 +213,26 @@ public actor JWTKeyCollection: Sendable {
     ///
     /// - Parameters:
     ///   - payload: The payload to sign.
-    ///   - typ: The JWT type header parameter. Defaults to "JWT".
-    ///   - kid: An optional key identifier to specify the signer. If not provided, the default signer is used.
-    ///   - x5c: An optional certificate chain to include in the header.
-    ///   - customFields: An optional dictionary of custom fields to include in the header.
+    ///   - kid: An optional key identifier to specify the signer.
+    ///         If not provided, the header is checked for a KID,
+    ///         and if that is not provided, the default signer is used.
+    ///   - header: An optional header to include in the JWT.
     /// - Throws: An error if the payload cannot be signed.
     /// - Returns: A signed JWT token string.
     public func sign(
         _ payload: some JWTPayload,
+        kid: JWKIdentifier? = nil,
         header: JWTHeader = JWTHeader()
     ) async throws -> String {
-        let kid = header.kid.flatMap { JWKIdentifier(string: $0) }
+        // Prioritise the provided kid
+        let effectiveKid = kid ?? header.kid.flatMap { JWKIdentifier(string: $0) }
+
+        // Update the header with the effective `kid`, if not nil.
+        var updatedHeader = header
+        if let effectiveKidValue = effectiveKid?.string {
+            updatedHeader.kid = effectiveKidValue
+        }
+
         let signer = try self.getSigner(for: kid, alg: header.alg)
         return try await signer.sign(payload, with: header)
     }

--- a/Sources/JWTKit/RSA/RSA.swift
+++ b/Sources/JWTKit/RSA/RSA.swift
@@ -1,4 +1,4 @@
-@preconcurrency import _CryptoExtras
+import _CryptoExtras
 import Crypto
 import Foundation
 import SwiftASN1

--- a/Tests/JWTKitTests/ECDSATests.swift
+++ b/Tests/JWTKitTests/ECDSATests.swift
@@ -33,7 +33,7 @@ final class ECDSATests: XCTestCase {
             admin: false,
             exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
         )
-        await XCTAssertThrowsErrorAsync(try await keys.sign(payload, header: ["kid": "public"])) { error in
+        await XCTAssertThrowsErrorAsync(try await keys.sign(payload, kid: "public")) { error in
             guard let error = error as? JWTError else {
                 XCTFail("Unexpected error: \(error)")
                 return
@@ -68,7 +68,7 @@ final class ECDSATests: XCTestCase {
             exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
         )
         for _ in 0 ..< 1000 {
-            let token = try await keys.sign(payload, header: ["kid": "private"])
+            let token = try await keys.sign(payload, kid: "private")
             // test private signer decoding
             try await XCTAssertEqualAsync(await keys.verify(token, as: TestPayload.self), payload)
             // test public signer decoding
@@ -92,7 +92,7 @@ final class ECDSATests: XCTestCase {
         let key = try ES384PrivateKey(key: privateKey)
         let keys = await JWTKeyCollection().addES384(key: key, kid: "vapor")
 
-        let jwt = try await keys.sign(Foo(bar: 42), header: ["kid": "vapor"])
+        let jwt = try await keys.sign(Foo(bar: 42), kid: "vapor")
 
         // verify using jwks without alg
         let jwksString = """
@@ -131,7 +131,7 @@ final class ECDSATests: XCTestCase {
         let key = try ES384PrivateKey(key: privateKey)
         let keys = await JWTKeyCollection().addES384(key: key, kid: "vapor")
 
-        let jwt = try await keys.sign(Foo(bar: 42), header: ["kid": "vapor"])
+        let jwt = try await keys.sign(Foo(bar: 42), kid: "vapor")
 
         // verify using jwks without alg
         let jwksString = """
@@ -170,7 +170,7 @@ final class ECDSATests: XCTestCase {
         let key = try ES384PrivateKey(key: privateKey)
         let keys = await JWTKeyCollection().addES384(key: key, kid: "vapor")
 
-        let jwt = try await keys.sign(Foo(bar: 42), header: ["kid": "vapor"])
+        let jwt = try await keys.sign(Foo(bar: 42), kid: "vapor")
 
         // verify using jwks without alg
         let jwksString = """

--- a/Tests/JWTKitTests/EdDSATests.swift
+++ b/Tests/JWTKitTests/EdDSATests.swift
@@ -29,7 +29,7 @@ final class EdDSATests: XCTestCase {
             exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
         )
         for _ in 0 ..< 1000 {
-            let token = try await keys.sign(payload, header: ["kid": "private"])
+            let token = try await keys.sign(payload, kid: "private")
             // test public signer decoding
             try await XCTAssertEqualAsync(await keys.verify(token, as: TestPayload.self), payload)
         }
@@ -123,7 +123,7 @@ final class EdDSATests: XCTestCase {
         let keyCollection = try await JWTKeyCollection()
             .addEdDSA(key: EdDSA.PrivateKey(x: x, d: d, curve: .ed25519), kid: "vapor")
 
-        let jwt = try await keyCollection.sign(Foo(bar: 42), header: ["kid": "vapor"])
+        let jwt = try await keyCollection.sign(Foo(bar: 42), kid: "vapor")
 
         // verify using jwks without alg
         let jwksString = """

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -431,6 +431,9 @@ class JWTKitTests: XCTestCase {
         await XCTAssertThrowsErrorAsync(try await keyCollection.sign(payload, header: ["kid": "public"]))
         let _ = try await keyCollection.sign(payload, kid: "private")
         await XCTAssertThrowsErrorAsync(try await keyCollection.sign(payload, kid: "public"))
+
+        let _ = try await keyCollection.sign(payload, kid: "private", header: ["kid": "public"])
+        await XCTAssertThrowsErrorAsync(try await keyCollection.sign(payload, kid: "public", header: ["kid": "private"]))
     }
 }
 

--- a/Tests/JWTKitTests/PSSTests.swift
+++ b/Tests/JWTKitTests/PSSTests.swift
@@ -35,7 +35,7 @@ final class PSSTests: XCTestCase {
             exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
         )
 
-        await XCTAssertThrowsErrorAsync(_ = try await keyCollection.sign(payload, header: ["kid": "private"]))
+        await XCTAssertThrowsErrorAsync(_ = try await keyCollection.sign(payload, kid: "private"))
     }
 
     func testJWTPayloadVerification() async throws {
@@ -138,7 +138,7 @@ final class PSSTests: XCTestCase {
             exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
         )
 
-        let token = try await keyCollection.sign(payload, header: ["kid": "private"])
+        let token = try await keyCollection.sign(payload, kid: "private")
         try await XCTAssertEqualAsync(await keyCollection.verify(token, as: TestPayload.self), payload)
     }
 

--- a/Tests/JWTKitTests/RSATests.swift
+++ b/Tests/JWTKitTests/RSATests.swift
@@ -48,7 +48,7 @@ final class RSATests: XCTestCase {
             exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
         )
 
-        let privateSigned = try await keyCollection.sign(payload, header: ["kid": "private"])
+        let privateSigned = try await keyCollection.sign(payload, kid: "private")
         try await XCTAssertEqualAsync(await keyCollection.verify(privateSigned, as: TestPayload.self), payload)
     }
 
@@ -139,7 +139,7 @@ final class RSATests: XCTestCase {
             .addRS256(key: Insecure.RSA.PrivateKey(pem: certPrivateKey), kid: "private")
             .addRS256(key: Insecure.RSA.PublicKey(certificatePEM: cert), kid: "cert")
 
-        let jwt = try await keyCollection.sign(test, header: ["kid": "private"])
+        let jwt = try await keyCollection.sign(test, kid: "private")
         let payload = try await keyCollection.verify(jwt, as: TestPayload.self)
         XCTAssertEqual(payload, test)
     }


### PR DESCRIPTION
This adds back the `kid` parameter to the `sign` function, since passing it in the header looks a bit funny: 
```swift
try await keyCollection.sign(somePayload, header: ["kid": .string(someKid.string)])
``` 
This can now be rewritten as
```swift
try await keyCollection.sign(somePayload, kid: someKid)
```
The passed in `kid` is prioritised, while the header is searched if none is passed in.
Also removes a now useless `@preconcurrency` attribute