### PR TITLE
Add primary associated type to ECDSAKey

### DIFF
--- a/Sources/JWTKit/ECDSA/ECDSA.swift
+++ b/Sources/JWTKit/ECDSA/ECDSA.swift
@@ -5,7 +5,7 @@ import X509
 
 public enum ECDSA: Sendable {}
 
-public protocol ECDSAKey: Sendable {
+public protocol ECDSAKey<Curve>: Sendable {
     associatedtype Curve: ECDSACurveType
     
     var curve: ECDSACurve { get }

--- a/Sources/JWTKit/ECDSA/JWTKeyCollection+ECDSA.swift
+++ b/Sources/JWTKit/ECDSA/JWTKeyCollection+ECDSA.swift
@@ -21,14 +21,12 @@ public extension JWTKeyCollection {
     ///          If `nil`, a default decoder is used.
     /// - Returns: The same instance of the collection (`Self`), which allows for method chaining.
     @discardableResult
-    func addES256<Key: ECDSAKey>(
+    func addES256<Key: ECDSAKey<P256>>(
         key: Key,
         kid: JWKIdentifier? = nil,
         parser: some JWTParser = DefaultJWTParser(),
         serializer: some JWTSerializer = DefaultJWTSerializer()
-    ) -> Self
-        where Key.Curve == P256
-    {
+    ) -> Self {
         add(.init(
             algorithm: ECDSASigner(key: key, algorithm: .sha256, name: "ES256"),
             parser: parser,
@@ -56,14 +54,12 @@ public extension JWTKeyCollection {
     ///          If `nil`, a default decoder is used.
     /// - Returns: The same instance of the collection (`Self`), which allows for method chaining.
     @discardableResult
-    func addES384<Key: ECDSAKey>(
+    func addES384<Key: ECDSAKey<P384>>(
         key: Key,
         kid: JWKIdentifier? = nil,
         parser: some JWTParser = DefaultJWTParser(),
         serializer: some JWTSerializer = DefaultJWTSerializer()
-    ) -> Self
-        where Key.Curve == P384
-    {
+    ) -> Self {
         add(.init(
             algorithm: ECDSASigner(key: key, algorithm: .sha384, name: "ES384"),
             parser: parser,
@@ -91,14 +87,12 @@ public extension JWTKeyCollection {
     ///          If `nil`, a default decoder is used.
     /// - Returns: The same instance of the collection (`Self`), which allows for method chaining.
     @discardableResult
-    func addES512<Key: ECDSAKey>(
+    func addES512<Key: ECDSAKey<P521>>(
         key: Key,
         kid: JWKIdentifier? = nil,
         parser: some JWTParser = DefaultJWTParser(),
         serializer: some JWTSerializer = DefaultJWTSerializer()
-    ) -> Self
-        where Key.Curve == P521
-    {
+    ) -> Self {
         add(.init(
             algorithm: ECDSASigner(key: key, algorithm: .sha512, name: "ES512"),
             parser: parser,


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Hello. I'm looking forward to jwt-kit v5 and trying it in my project.

I would like to propose adding a primary associated type (PAT) to `ECDSAKey` protocol. 
In my project, the key type is dynamic because it changes the type depending to environment variables.
Here is an example to illustrate the situation.

```swift
struct Key {
    func toECDSAKey() -> any ECDSAKey /* <P256> */  {
        // returns public or private key
    }
}

func setup(key: Key) async {
    let keys = JWTKeyCollection()
    await keys.addES256(key: key.toECDSAKey()) // Instance method 'addES256(key:kid:parser:serializer:)' requires the types 'Key.Curve' and 'P256' be equivalent
}
```

Currently, it is not possible to call `addES256` due to the lack of PAT in `ECDSAKey`. Incorporating PAT into `ECDSAKey` would resolve this issue.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
