### PR TITLE
Cache JWKSigner when possible

### DIFF
--- a/Sources/JWTKit/JWK/JWKSigner.swift
+++ b/Sources/JWTKit/JWK/JWKSigner.swift
@@ -11,8 +11,7 @@ final class JWKSigner: Sendable {
         serializer: some JWTSerializer = DefaultJWTSerializer()
     ) throws {
         self.jwk = jwk
-        let algorithm = try jwk.getKey()
-        if let algorithm {
+        if let algorithm = try jwk.getKey() {
             self.signer = .init(algorithm: algorithm, parser: parser, serializer: serializer)
         } else {
             self.signer = nil

--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -116,7 +116,9 @@ public struct JWTError: Error, Sendable {
         .init(backing: .init(errorType: .unknownKID, kid: kid))
     }
 
-    public static let invalidJWK = Self(errorType: .invalidJWK)
+    public static func invalidJWK(reason: String) -> Self {
+        .init(backing: .init(errorType: .invalidJWK, reason: reason))
+    }
 
     public static func invalidBool(_ name: String) -> Self {
         .init(backing: .init(errorType: .invalidBool, name: name))

--- a/Sources/JWTKit/JWTKeyCollection.swift
+++ b/Sources/JWTKit/JWTKeyCollection.swift
@@ -29,7 +29,7 @@ public actor JWTKeyCollection: Sendable {
         defaultJWTSerializer: some JWTSerializer = DefaultJWTSerializer(),
         logger: Logger = Logger(label: "jwt_kit_do_not_log", factory: { _ in SwiftLogNoOpLogHandler() })
     ) {
-        storage = [:]
+        self.storage = [:]
         self.defaultJWTParser = defaultJWTParser
         self.defaultJWTSerializer = defaultJWTSerializer
         self.logger = logger
@@ -49,12 +49,12 @@ public actor JWTKeyCollection: Sendable {
 
         if let kid {
             if self.storage[kid] != nil {
-                logger.debug("Overwriting existing JWT signer", metadata: ["kid": "\(kid)"])
+                self.logger.debug("Overwriting existing JWT signer", metadata: ["kid": "\(kid)"])
             }
             self.storage[kid] = .jwt(signer)
         } else {
             if self.default != nil {
-                logger.debug("Overwriting existing default JWT signer")
+                self.logger.debug("Overwriting existing default JWT signer")
             }
             self.default = .jwt(signer)
         }
@@ -150,7 +150,7 @@ public actor JWTKeyCollection: Sendable {
     /// - Returns: A ``JWTKey`` if one is found; otherwise, `nil`.
     /// - Throws: ``JWTError/generic`` if the algorithm cannot be retrieved.
     public func getKey(for kid: JWKIdentifier? = nil, alg: String? = nil) throws -> JWTAlgorithm {
-        try getSigner(for: kid, alg: alg).algorithm
+        try self.getSigner(for: kid, alg: alg).algorithm
     }
 
     /// Decodes an unverified JWT payload.
@@ -186,7 +186,7 @@ public actor JWTKeyCollection: Sendable {
     ) throws -> Payload
         where Payload: JWTPayload
     {
-        try (parser ?? defaultJWTParser).parse(token, as: Payload.self).payload
+        try (parser ?? self.defaultJWTParser).parse(token, as: Payload.self).payload
     }
 
     /// Verifies and decodes a JWT token to extract the payload.

--- a/Sources/JWTKit/JWTSigner.swift
+++ b/Sources/JWTKit/JWTSigner.swift
@@ -7,7 +7,7 @@ final class JWTSigner: Sendable {
     let parser: any JWTParser
     let serializer: any JWTSerializer
 
-    init(algorithm: JWTAlgorithm, parser: some JWTParser = DefaultJWTParser(), serializer: some JWTSerializer = DefaultJWTSerializer()) {
+    init(algorithm: JWTAlgorithm, parser: any JWTParser = DefaultJWTParser(), serializer: any JWTSerializer = DefaultJWTSerializer()) {
         self.algorithm = algorithm
         self.parser = parser
         self.serializer = serializer

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -193,6 +193,7 @@ class JWTKitTests: XCTestCase {
             exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
         )
         let data = try await keyCollection.sign(payload, kid: "1234")
+
         // test private signer decoding
         try await XCTAssertEqualAsync(await keyCollection.verify(data, as: TestPayload.self), payload)
         // test public signer decoding
@@ -212,7 +213,7 @@ class JWTKitTests: XCTestCase {
         let keyCollection = try await JWTKeyCollection().use(jwksJSON: json)
 
         await XCTAssertNoThrowAsync(try await keyCollection.getKey())
-        var a: JWTAlgorithm, b: JWTAlgorithm
+        let a: JWTAlgorithm, b: JWTAlgorithm
         do {
             a = try await keyCollection.getKey(for: "a")
         } catch {


### PR DESCRIPTION
Instead of creating a new signer for JWKs each time, try caching it if we know the algorithm upfront