### PR TITLE
Fix decimal and nil header encoding

### DIFF
--- a/Sources/JWTKit/JWTHeader.swift
+++ b/Sources/JWTKit/JWTHeader.swift
@@ -8,21 +8,31 @@ public struct JWTHeader: Sendable {
     }
 
     public subscript(dynamicMember member: String) -> JWTHeaderField? {
-        get { fields[member] }
-        set { fields[member] = newValue }
+        get { self.fields[member] }
+        set {
+            if let newValue = newValue {
+                self.fields[member] = newValue
+            } else {
+                self.fields[member] = .null
+            }
+        }
+    }
+
+    public mutating func removeField(_ key: String) {
+        self.fields.removeValue(forKey: key)
     }
 }
 
 extension JWTHeader: ExpressibleByDictionaryLiteral {
-     public init(dictionaryLiteral elements: (String, JWTHeaderField)...) {
-         self.init(fields: Dictionary(uniqueKeysWithValues: elements))
-     }
- }
+    public init(dictionaryLiteral elements: (String, JWTHeaderField)...) {
+        self.init(fields: Dictionary(uniqueKeysWithValues: elements))
+    }
+}
 
 extension JWTHeader: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try fields.forEach { key, value in
+        try self.fields.forEach { key, value in
             try container.encode(value, forKey: .custom(name: key))
         }
     }

--- a/Sources/JWTKit/JWTHeader.swift
+++ b/Sources/JWTKit/JWTHeader.swift
@@ -18,8 +18,8 @@ public struct JWTHeader: Sendable {
         }
     }
 
-    public mutating func removeField(_ key: String) {
-        self.fields.removeValue(forKey: key)
+    public mutating func remove(_ field: String) {
+        self.fields.removeValue(forKey: field)
     }
 }
 

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -604,6 +604,21 @@ class JWTKitTests: XCTestCase {
 
         XCTAssertEqual(unverified, payload)
     }
+
+    func testRemoveHeaderField() {
+        var header = JWTHeader()
+
+        header.field1 = "value1"
+        header.field2 = "value2"
+
+        XCTAssertEqual(header.fields.count, 2)
+
+        header.remove("field1")
+
+        XCTAssertEqual(header.fields.count, 1)
+        XCTAssertNil(header.field1)
+        XCTAssertEqual(header.field2, .string("value2"))
+    }
 }
 
 struct AudiencePayload: Codable {


### PR DESCRIPTION
This aims to fix the issues discovered in #188
1. `nil` wasn't being added because assigning `nil` to a field would remove it from the dict. Now assigning `nil` to a field actually adds an explicit null value to the json, while there's a `remove(field:)` method to remove fields from the header
2. `decimal` wasn't being decoded correctly because it was trying to unwrap `Double`s as `Int`s