### PR TITLE
Add availability annotations to unavailable crypto properties

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,7 @@ jobs:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: macos-latest
     steps:
-      - name: Run iOS Tests on iOS
+      - name: Check out JWTKit
+        uses: actions/checkout@v4
+      - name: Run iOS Tests
         run: xcodebuild -scheme jwt-kit -destination generic/platform=iOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,5 @@ jobs:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: macos-latest
     steps:
-      - name: Check out JWTKit
-        uses: actions/checkout@v4
-      - name: Run iOS Tests on iOS 15
-        run: xcodebuild test -scheme jwt-kit -destination 'platform=iOS Simulator,name=iPhone 13,OS=15.0'
-      - name: Run iOS Tests on iOS 16
-        run: xcodebuild test -scheme jwt-kit -destination 'platform=iOS Simulator,name=iPhone 13,OS=16.0'
+      - name: Run iOS Tests on iOS
+        run: xcrun xcodebuild -scheme jwt-kit -destination generic/platform=iOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Run iOS Tests on iOS
-        run: xcrun xcodebuild -scheme jwt-kit -destination generic/platform=iOS
+        run: xcodebuild -scheme jwt-kit -destination generic/platform=iOS

--- a/Sources/JWTKit/ECDSA/ECDSAKeyTypes.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKeyTypes.swift
@@ -41,6 +41,7 @@ public protocol ECDSAPublicKey: Sendable {
     init(rawRepresentation: some ContiguousBytes) throws
     init(compactRepresentation: some ContiguousBytes) throws
     init(x963Representation: some ContiguousBytes) throws
+    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
     init(compressedRepresentation: some ContiguousBytes) throws
     init(pemRepresentation: String) throws
     init<Bytes>(derRepresentation: Bytes) throws where Bytes: RandomAccessCollection, Bytes.Element == UInt8
@@ -48,6 +49,7 @@ public protocol ECDSAPublicKey: Sendable {
     var compactRepresentation: Data? { get }
     var rawRepresentation: Data { get }
     var x963Representation: Data { get }
+    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
     var compressedRepresentation: Data { get }
     var derRepresentation: Data { get }
     var pemRepresentation: String { get }

--- a/Sources/JWTKit/ECDSA/ECDSAKeyTypes.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKeyTypes.swift
@@ -41,7 +41,7 @@ public protocol ECDSAPublicKey: Sendable {
     init(rawRepresentation: some ContiguousBytes) throws
     init(compactRepresentation: some ContiguousBytes) throws
     init(x963Representation: some ContiguousBytes) throws
-    // @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
     init(compressedRepresentation: some ContiguousBytes) throws
     init(pemRepresentation: String) throws
     init<Bytes>(derRepresentation: Bytes) throws where Bytes: RandomAccessCollection, Bytes.Element == UInt8
@@ -49,7 +49,7 @@ public protocol ECDSAPublicKey: Sendable {
     var compactRepresentation: Data? { get }
     var rawRepresentation: Data { get }
     var x963Representation: Data { get }
-    // @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
     var compressedRepresentation: Data { get }
     var derRepresentation: Data { get }
     var pemRepresentation: String { get }

--- a/Sources/JWTKit/ECDSA/ECDSAKeyTypes.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKeyTypes.swift
@@ -41,7 +41,7 @@ public protocol ECDSAPublicKey: Sendable {
     init(rawRepresentation: some ContiguousBytes) throws
     init(compactRepresentation: some ContiguousBytes) throws
     init(x963Representation: some ContiguousBytes) throws
-    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+    // @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
     init(compressedRepresentation: some ContiguousBytes) throws
     init(pemRepresentation: String) throws
     init<Bytes>(derRepresentation: Bytes) throws where Bytes: RandomAccessCollection, Bytes.Element == UInt8
@@ -49,7 +49,7 @@ public protocol ECDSAPublicKey: Sendable {
     var compactRepresentation: Data? { get }
     var rawRepresentation: Data { get }
     var x963Representation: Data { get }
-    @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+    // @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
     var compressedRepresentation: Data { get }
     var derRepresentation: Data { get }
     var pemRepresentation: String { get }


### PR DESCRIPTION
Since adding support for iOS 15, builds started failing at https://swiftpackageindex.com/builds/495EA704-A76E-4078-BAA9-617D0769824E because of an unavailable property (namely `compressedRepresentation`) which is available from iOS 16 on. This adds annotations to make the property unavailable to iOS 15 (and therefore using Crypto's implementation)

Fixes #191 