### PR TITLE
Add `RSA-OAEP` to JWK algorithms to support decoding.

### DIFF
--- a/Sources/JWTKit/JWK/JWK.swift
+++ b/Sources/JWTKit/JWK/JWK.swift
@@ -143,6 +143,8 @@ public struct JWK: Codable, Sendable {
         public static let es512 = Self(backing: .es512)
         /// EdDSA
         public static let eddsa = Self(backing: .eddsa)
+        /// RSA with OAEP
+        public static let rsaOAEP = Self(backing: .rsaOAEP)
 
         enum Backing: String, Codable {
             case rs256 = "RS256"
@@ -155,6 +157,7 @@ public struct JWK: Codable, Sendable {
             case es384 = "ES384"
             case es512 = "ES512"
             case eddsa = "EdDSA"
+            case rsaOAEP = "RSA-OAEP"
         }
 
         init(backing: Backing) {


### PR DESCRIPTION
Fixes an issue where a JWKS failed to decode because it also contains encryption keys and therefore `alg` such as `RSA-OAEP`.

This does not add support for the cipher, but at least it will allow us to decode JWKS to use for signing where we might not be able to remove the encryption keys from the remote JWKS.