### PR TITLE
Add `MLDSA{65,87}` support inside new `_QuantumJWTKit` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Packages
 .build
+.index-build
 .DS_Store
 *.xcodeproj
 Package.pins

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "JWTKit", targets: ["JWTKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", "3.8.0"..<"5.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
@@ -27,10 +27,25 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
             ]
         ),
+        .target(
+            name: "_QuantumJWTKit",
+            dependencies: [
+                "JWTKit",
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "_CryptoExtras", package: "swift-crypto"),
+            ]
+        ),
         .testTarget(
             name: "JWTKitTests",
             dependencies: [
                 "JWTKit"
+            ]
+        ),
+        .testTarget(
+            name: "_QuantumJWTKitTests",
+            dependencies: [
+                "JWTKit",
+                "_QuantumJWTKit",
             ]
         ),
     ]

--- a/Sources/JWTKit/JWTKeyCollection.swift
+++ b/Sources/JWTKit/JWTKeyCollection.swift
@@ -32,8 +32,7 @@ public actor JWTKeyCollection: Sendable {
     public init(
         defaultJWTParser: some JWTParser = DefaultJWTParser(),
         defaultJWTSerializer: some JWTSerializer = DefaultJWTSerializer(),
-        logger: Logger = Logger(
-            label: "jwt_kit_do_not_log", factory: { _ in SwiftLogNoOpLogHandler() })
+        logger: Logger = Logger(label: "jwt_kit_do_not_log", factory: { _ in SwiftLogNoOpLogHandler() })
     ) {
         self.storage = [:]
         self.defaultJWTParser = defaultJWTParser
@@ -51,8 +50,7 @@ public actor JWTKeyCollection: Sendable {
     /// - Returns: Self for chaining.
     @discardableResult
     package func add(_ signer: JWTSigner, for kid: JWKIdentifier? = nil) -> Self {
-        let signer = JWTSigner(
-            algorithm: signer.algorithm, parser: signer.parser, serializer: signer.serializer)
+        let signer = JWTSigner(algorithm: signer.algorithm, parser: signer.parser, serializer: signer.serializer)
 
         if let kid {
             if self.storage[kid] != nil {
@@ -107,8 +105,7 @@ public actor JWTKeyCollection: Sendable {
         guard let kid = jwk.keyIdentifier else {
             throw JWTError.invalidJWK(reason: "Missing KID")
         }
-        let signer = try JWKSigner(
-            jwk: jwk, parser: defaultJWTParser, serializer: defaultJWTSerializer)
+        let signer = try JWKSigner(jwk: jwk, parser: defaultJWTParser, serializer: defaultJWTSerializer)
 
         self.storage[kid] = .jwk(signer)
         switch (self.default, isDefault) {
@@ -144,9 +141,7 @@ public actor JWTKeyCollection: Sendable {
             } else {
                 guard let alg, let jwkAlg = JWK.Algorithm(rawValue: alg) else {
                     throw JWTError.generic(
-                        identifier: "Algorithm",
-                        reason:
-                            "Invalid algorithm or unable to create signer with provided algorithm."
+                        identifier: "Algorithm", reason: "Invalid algorithm or unable to create signer with provided algorithm."
                     )
                 }
                 return try await jwk.makeSigner(for: jwkAlg)

--- a/Sources/JWTKit/JWTKeyCollection.swift
+++ b/Sources/JWTKit/JWTKeyCollection.swift
@@ -32,7 +32,8 @@ public actor JWTKeyCollection: Sendable {
     public init(
         defaultJWTParser: some JWTParser = DefaultJWTParser(),
         defaultJWTSerializer: some JWTSerializer = DefaultJWTSerializer(),
-        logger: Logger = Logger(label: "jwt_kit_do_not_log", factory: { _ in SwiftLogNoOpLogHandler() })
+        logger: Logger = Logger(
+            label: "jwt_kit_do_not_log", factory: { _ in SwiftLogNoOpLogHandler() })
     ) {
         self.storage = [:]
         self.defaultJWTParser = defaultJWTParser
@@ -49,7 +50,7 @@ public actor JWTKeyCollection: Sendable {
     ///   - kid: An optional ``JWKIdentifier`` to associate with the signer.
     /// - Returns: Self for chaining.
     @discardableResult
-    func add(_ signer: JWTSigner, for kid: JWKIdentifier? = nil) -> Self {
+    package func add(_ signer: JWTSigner, for kid: JWKIdentifier? = nil) -> Self {
         let signer = JWTSigner(
             algorithm: signer.algorithm, parser: signer.parser, serializer: signer.serializer)
 
@@ -143,7 +144,9 @@ public actor JWTKeyCollection: Sendable {
             } else {
                 guard let alg, let jwkAlg = JWK.Algorithm(rawValue: alg) else {
                     throw JWTError.generic(
-                        identifier: "Algorithm", reason: "Invalid algorithm or unable to create signer with provided algorithm."
+                        identifier: "Algorithm",
+                        reason:
+                            "Invalid algorithm or unable to create signer with provided algorithm."
                     )
                 }
                 return try await jwk.makeSigner(for: jwkAlg)
@@ -157,7 +160,9 @@ public actor JWTKeyCollection: Sendable {
     ///  - alg: An optional algorithm identifier.
     /// - Returns: A ``JWTKey`` if one is found; otherwise, `nil`.
     /// - Throws: ``JWTError/generic`` if the algorithm cannot be retrieved.
-    public func getKey(for kid: JWKIdentifier? = nil, alg: String? = nil) async throws -> any JWTAlgorithm {
+    public func getKey(for kid: JWKIdentifier? = nil, alg: String? = nil) async throws
+        -> any JWTAlgorithm
+    {
         try await self.getSigner(for: kid, alg: alg).algorithm
     }
 

--- a/Sources/JWTKit/JWTSigner.swift
+++ b/Sources/JWTKit/JWTSigner.swift
@@ -5,13 +5,13 @@
 #endif
 
 /// A JWT signer.
-final class JWTSigner: Sendable {
+package final class JWTSigner: Sendable {
     let algorithm: JWTAlgorithm
 
     let parser: any JWTParser
     let serializer: any JWTSerializer
 
-    init(
+    package init(
         algorithm: some JWTAlgorithm,
         parser: any JWTParser = DefaultJWTParser(),
         serializer: any JWTSerializer = DefaultJWTSerializer()
@@ -25,7 +25,8 @@ final class JWTSigner: Sendable {
         try await serializer.sign(payload, with: header, using: self.algorithm)
     }
 
-    func verify<Payload>(_ token: some DataProtocol) async throws -> Payload where Payload: JWTPayload {
+    func verify<Payload>(_ token: some DataProtocol) async throws -> Payload
+    where Payload: JWTPayload {
         let (encodedHeader, encodedPayload, encodedSignature) = try parser.getTokenParts(token)
         let data = encodedHeader + [.period] + encodedPayload
         let signature = encodedSignature.base64URLDecodedBytes()

--- a/Sources/JWTKit/JWTSigner.swift
+++ b/Sources/JWTKit/JWTSigner.swift
@@ -25,8 +25,7 @@ package final class JWTSigner: Sendable {
         try await serializer.sign(payload, with: header, using: self.algorithm)
     }
 
-    func verify<Payload>(_ token: some DataProtocol) async throws -> Payload
-    where Payload: JWTPayload {
+    func verify<Payload>(_ token: some DataProtocol) async throws -> Payload where Payload: JWTPayload {
         let (encodedHeader, encodedPayload, encodedSignature) = try parser.getTokenParts(token)
         let data = encodedHeader + [.period] + encodedPayload
         let signature = encodedSignature.base64URLDecodedBytes()

--- a/Sources/_QuantumJWTKit/MLDSA/JWTKeyCollection+MLDSA.swift
+++ b/Sources/_QuantumJWTKit/MLDSA/JWTKeyCollection+MLDSA.swift
@@ -1,0 +1,16 @@
+import JWTKit
+
+extension JWTKeyCollection {
+    @discardableResult
+    public func add(
+        mldsa key: some MLDSAKey,
+        kid: JWKIdentifier? = nil,
+        parser: some JWTParser = DefaultJWTParser(),
+        serializer: some JWTSerializer = DefaultJWTSerializer()
+    ) -> Self {
+        self.add(
+            .init(algorithm: MLDSASigner(key: key), parser: parser, serializer: serializer),
+            for: kid
+        )
+    }
+}

--- a/Sources/_QuantumJWTKit/MLDSA/MLDSA.swift
+++ b/Sources/_QuantumJWTKit/MLDSA/MLDSA.swift
@@ -1,0 +1,49 @@
+import _CryptoExtras
+
+#if !canImport(Darwin)
+    import FoundationEssentials
+#else
+    import Foundation
+#endif
+
+public enum MLDSA: Sendable {}
+
+extension MLDSA {
+    public struct PublicKey<KeyType>: MLDSAKey where KeyType: MLDSAType {
+        public typealias MLDSAType = KeyType
+
+        typealias PublicKey = KeyType.PrivateKey.PublicKey
+
+        let backing: any MLDSAPublicKey
+
+        public init(backing: some MLDSAPublicKey) {
+            self.backing = backing
+        }
+
+        public init(rawRepresentation: some DataProtocol) throws {
+            self.backing = try PublicKey(rawRepresentation: rawRepresentation)
+        }
+    }
+}
+
+extension MLDSA {
+    public struct PrivateKey<KeyType>: MLDSAKey where KeyType: MLDSAType {
+        public typealias MLDSAType = KeyType
+
+        typealias PrivateKey = KeyType.PrivateKey
+
+        let backing: any MLDSAPrivateKey
+
+        public var publicKey: MLDSA.PublicKey<KeyType> {
+            .init(backing: self.backing.publicKey)
+        }
+
+        public init(backing: some MLDSAPrivateKey) {
+            self.backing = backing
+        }
+
+        public init(seedRepresentation: some DataProtocol) throws {
+            self.backing = try PrivateKey(seedRepresentation: seedRepresentation)
+        }
+    }
+}

--- a/Sources/_QuantumJWTKit/MLDSA/MLDSA65+MLDSAKey.swift
+++ b/Sources/_QuantumJWTKit/MLDSA/MLDSA65+MLDSAKey.swift
@@ -1,0 +1,12 @@
+import _CryptoExtras
+
+extension MLDSA65.PublicKey: MLDSAPublicKey {
+    public typealias MLDSAType = MLDSA65
+}
+
+extension MLDSA65.PrivateKey: MLDSAPrivateKey {
+    public typealias MLDSAType = MLDSA65
+}
+
+public typealias MLDSA65PublicKey = MLDSA.PublicKey<MLDSA65>
+public typealias MLDSA65PrivateKey = MLDSA.PrivateKey<MLDSA65>

--- a/Sources/_QuantumJWTKit/MLDSA/MLDSA87+MLDSAKey.swift
+++ b/Sources/_QuantumJWTKit/MLDSA/MLDSA87+MLDSAKey.swift
@@ -1,0 +1,12 @@
+import _CryptoExtras
+
+extension MLDSA87.PublicKey: MLDSAPublicKey {
+    public typealias MLDSAType = MLDSA87
+}
+
+extension MLDSA87.PrivateKey: MLDSAPrivateKey {
+    public typealias MLDSAType = MLDSA87
+}
+
+public typealias MLDSA87PublicKey = MLDSA.PublicKey<MLDSA87>
+public typealias MLDSA87PrivateKey = MLDSA.PrivateKey<MLDSA87>

--- a/Sources/_QuantumJWTKit/MLDSA/MLDSAError.swift
+++ b/Sources/_QuantumJWTKit/MLDSA/MLDSAError.swift
@@ -1,0 +1,5 @@
+enum MLDSAError: Error {
+    case noPrivateKey
+    case noPublicKey
+    case failedToSign(Error)
+}

--- a/Sources/_QuantumJWTKit/MLDSA/MLDSAKey.swift
+++ b/Sources/_QuantumJWTKit/MLDSA/MLDSAKey.swift
@@ -1,0 +1,31 @@
+#if canImport(FoundationEssentials)
+    import FoundationEssentials
+#else
+    import Foundation
+#endif
+
+public protocol MLDSAKey: Sendable {
+    associatedtype MLDSAType: _QuantumJWTKit.MLDSAType
+}
+
+public protocol MLDSAPublicKey: Sendable {
+    associatedtype MLDSAType
+
+    init(rawRepresentation: some DataProtocol) throws
+    var rawRepresentation: Data { get }
+    func isValidSignature<S: DataProtocol, D: DataProtocol>(_ signature: S, for data: D) -> Bool
+    func isValidSignature<S: DataProtocol, D: DataProtocol, C: DataProtocol>(
+        _ signature: S, for data: D, context: C
+    ) -> Bool
+}
+
+public protocol MLDSAPrivateKey: Sendable {
+    associatedtype MLDSAType
+    associatedtype PublicKey: MLDSAPublicKey
+
+    var seedRepresentation: Data { get }
+    var publicKey: PublicKey { get }
+    init(seedRepresentation: some DataProtocol) throws
+    func signature<D: DataProtocol>(for data: D) throws -> Data
+    func signature<D: DataProtocol, C: DataProtocol>(for data: D, context: C) throws -> Data
+}

--- a/Sources/_QuantumJWTKit/MLDSA/MLDSASigner.swift
+++ b/Sources/_QuantumJWTKit/MLDSA/MLDSASigner.swift
@@ -1,0 +1,47 @@
+import JWTKit
+import _CryptoExtras
+
+#if canImport(FoundationEssentials)
+    import FoundationEssentials
+#else
+    import Foundation
+#endif
+
+struct MLDSASigner<Key: MLDSAKey>: JWTAlgorithm, Sendable {
+    let privateKey: MLDSA.PrivateKey<Key.MLDSAType>?
+    let publicKey: MLDSA.PublicKey<Key.MLDSAType>
+
+    var name: String = Key.MLDSAType.name
+
+    init(key: Key) {
+        switch key {
+        case let key as MLDSA.PrivateKey<Key.MLDSAType>:
+            self.privateKey = key
+            self.publicKey = key.publicKey
+        case let key as MLDSA.PublicKey<Key.MLDSAType>:
+            self.privateKey = nil
+            self.publicKey = key
+        default:
+            fatalError()
+        }
+    }
+
+    func sign(_ plaintext: some DataProtocol) throws -> [UInt8] {
+        guard let privateKey else {
+            throw JWTError.signingAlgorithmFailure(MLDSAError.noPrivateKey)
+        }
+
+        let signature: Data
+        do {
+            signature = try privateKey.backing.signature(for: plaintext)
+        } catch {
+            throw JWTError.signingAlgorithmFailure(MLDSAError.failedToSign(error))
+        }
+
+        return signature.copyBytes()
+    }
+
+    func verify(_ signature: some DataProtocol, signs plaintext: some DataProtocol) throws -> Bool {
+        publicKey.backing.isValidSignature(signature, for: plaintext)
+    }
+}

--- a/Sources/_QuantumJWTKit/MLDSA/MLDSAType.swift
+++ b/Sources/_QuantumJWTKit/MLDSA/MLDSAType.swift
@@ -1,0 +1,15 @@
+import _CryptoExtras
+
+public protocol MLDSAType {
+    associatedtype PrivateKey: MLDSAPrivateKey
+
+    static var name: String { get }
+}
+
+extension MLDSA65: MLDSAType {
+    public static var name: String { "ML-DSA-65" }
+}
+
+extension MLDSA87: MLDSAType {
+    public static var name: String { "ML-DSA-87" }
+}

--- a/Tests/_QuantumJWTKitTests/MLDSATests.swift
+++ b/Tests/_QuantumJWTKitTests/MLDSATests.swift
@@ -1,0 +1,79 @@
+import Crypto
+import Foundation
+import JWTKit
+import Testing
+import _QuantumJWTKit
+
+@Suite("MLDSA Tests")
+struct MLDSATests {
+    @Test("MLDSA65 Signing")
+    func sign65() async throws {
+        struct Foo: JWTPayload {
+            var bar: Int
+            func verify(using _: some JWTAlgorithm) throws {}
+        }
+
+        let key = try MLDSA65PrivateKey(
+            seedRepresentation: Data(fromHexEncodedString: mldsa65PrivateKeySeedRepresentation)!)
+
+        let keyCollection = JWTKeyCollection()
+        await keyCollection.add(mldsa: key)
+
+        let jwt = try await keyCollection.sign(Foo(bar: 42))
+        let verified = try await keyCollection.verify(jwt, as: Foo.self)
+
+        #expect(verified.bar == 42)
+    }
+
+    @Test("MLDSA87 Signing")
+    func sign87() async throws {
+        struct Foo: JWTPayload {
+            var bar: Int
+            func verify(using _: some JWTAlgorithm) throws {}
+        }
+
+        let key = try MLDSA87PrivateKey(
+            seedRepresentation: Data(fromHexEncodedString: mldsa65PrivateKeySeedRepresentation)!)
+
+        let keyCollection = JWTKeyCollection()
+        await keyCollection.add(mldsa: key)
+
+        let jwt = try await keyCollection.sign(Foo(bar: 42))
+        let verified = try await keyCollection.verify(jwt, as: Foo.self)
+
+        #expect(verified.bar == 42)
+
+        print(jwt)
+    }
+}
+
+let mldsa65PrivateKeySeedRepresentation =
+    "70cefb9aed5b68e018b079da8284b9d5cad5499ed9c265ff73588005d85c225c"
+
+let mldsa87PrivateKeySeedRepresentation =
+    "19e9e5efe0c1549ddb1d72213636d16fe2faeb2428257004ae464094ca536a66"
+
+extension Data {
+    init?(fromHexEncodedString string: String) {
+        func decodeNibble(u: UInt8) -> UInt8? {
+            switch u {
+            case 0x30...0x39: u - 0x30
+            case 0x41...0x46: u - 0x41 + 10
+            case 0x61...0x66: u - 0x61 + 10
+            default: nil
+            }
+        }
+
+        self.init(capacity: string.utf8.count / 2)
+
+        var iter = string.utf8.makeIterator()
+        while let c1 = iter.next() {
+            guard
+                let val1 = decodeNibble(u: c1),
+                let c2 = iter.next(),
+                let val2 = decodeNibble(u: c2)
+            else { return nil }
+            self.append(val1 << 4 + val2)
+        }
+    }
+}


### PR DESCRIPTION
Since swift-crypto now supports ML-DSA{65,87}, this adds support for ML-DSA based JWTs. While ML-DSA is now a formalised standard ([RFC 204](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf)), its usage in JOSE is still in [draft](https://datatracker.ietf.org/doc/draft-ietf-cose-dilithium/) state, which means its specifications could change. We're therefore placing it in a new, underscored (and consequently non API-stable, even though public) module called `_QuantumJWTKit`.

This PR is currently refers to the main branch of swift-crypto since no release has yet been tagged with the new post-quantum algorithms. This will change as soon as a decision is made whether to release the new APIs as a minor release _before_ the new 2026 Crypto major release, or to wait and have them in the main Crypto module. (Discussion happening [here](https://github.com/apple/swift-crypto/pull/359#issuecomment-2959350833))