### PR TITLE
Make rawRepresentation and publicKey of EdDSA keys public

### DIFF
--- a/Sources/JWTKit/EdDSA/EdDSA.swift
+++ b/Sources/JWTKit/EdDSA/EdDSA.swift
@@ -61,7 +61,7 @@ extension EdDSA {
             self.init(backing: key)
         }
 
-        var rawRepresentation: Data {
+        public var rawRepresentation: Data {
             self.backing.rawRepresentation
         }
     }
@@ -132,11 +132,11 @@ extension EdDSA {
             self.init(backing: key)
         }
 
-        var publicKey: PublicKey {
+        public var publicKey: PublicKey {
             .init(backing: self.backing.publicKey)
         }
 
-        var rawRepresentation: Data {
+        public var rawRepresentation: Data {
             self.backing.rawRepresentation
         }
     }


### PR DESCRIPTION
**These changes are now available in [5.2.0](https://github.com/vapor/jwt-kit/releases/tag/5.2.0)**


Make `rawRepresentation` of EdDSA keys public
Make `publicKey` of EdDSA.PrivateKey public