### PR TITLE
Fix for not honoring ValidationTimePayload's signedDate

### DIFF
--- a/Sources/JWTKit/X5C/EmptyPolicy.swift
+++ b/Sources/JWTKit/X5C/EmptyPolicy.swift
@@ -1,0 +1,24 @@
+//
+//  AlwaysMeetsPolicy.swift
+//  jwt-kit
+//
+//  Created by Bastian Rössler on 02.07.25.
+//
+
+import X509
+import SwiftASN1
+
+/// This Policy acts as a placeholder. Its result is always positive.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+public struct EmptyPolicy: VerifierPolicy {
+    @inlinable
+    public var verifyingCriticalExtensions: [SwiftASN1.ASN1ObjectIdentifier] { [] }
+
+    @inlinable
+    init() {}
+
+    @inlinable
+    public func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
+        return .meetsPolicy
+    }
+}

--- a/Sources/JWTKit/X5C/X5CVerifier.swift
+++ b/Sources/JWTKit/X5C/X5CVerifier.swift
@@ -74,7 +74,7 @@ public struct X5CVerifier: Sendable {
     /// - Returns: A `X509.VerificationResult` indicating the result of the verification.
     public func verifyChain(
         certificates: [Certificate],
-        @PolicyBuilder policy: () throws -> some VerifierPolicy = { RFC5280Policy(validationTime: Date()) }
+        @PolicyBuilder policy: () throws -> some VerifierPolicy = { EmptyPolicy() }
     ) async throws -> X509.VerificationResult {
         let untrustedChain = CertificateStore(certificates)
         var verifier = try Verifier(rootCertificates: trustedStore, policy: policy)

--- a/Sources/JWTKit/X5C/X5CVerifier.swift
+++ b/Sources/JWTKit/X5C/X5CVerifier.swift
@@ -74,7 +74,7 @@ public struct X5CVerifier: Sendable {
     /// - Returns: A `X509.VerificationResult` indicating the result of the verification.
     public func verifyChain(
         certificates: [Certificate],
-        @PolicyBuilder policy: () throws -> some VerifierPolicy = { EmptyPolicy() }
+        @PolicyBuilder policy: () throws -> some VerifierPolicy = { RFC5280Policy(validationTime: Date()) }
     ) async throws -> X509.VerificationResult {
         let untrustedChain = CertificateStore(certificates)
         var verifier = try Verifier(rootCertificates: trustedStore, policy: policy)
@@ -141,7 +141,7 @@ public struct X5CVerifier: Sendable {
         _ token: some DataProtocol,
         as _: Payload.Type = Payload.self,
         jsonDecoder: any JWTJSONDecoder,
-        @PolicyBuilder policy: () throws -> some VerifierPolicy = { RFC5280Policy(validationTime: Date()) }
+        @PolicyBuilder policy: () throws -> some VerifierPolicy = { EmptyPolicy() }
     ) async throws -> Payload
     where Payload: JWTPayload {
         // Parse the JWS header to get the header


### PR DESCRIPTION
# Bug Description
When using the `X5CVerifier` to verify a Payload that conforms to `ValidationTimePayload` the `signedDate` of the `ValidationTimePayload` would be used to initialize a `RFC5280Policy`. Unfortunately the default `@PolicyBuilder` that is used in the respective `verifyJWS` function also contained a `RFC5280Policy`, which was always initialized to the current date.

As both policies need to be met in order for the verification to succeed, the `ValidationTimePayload`'s `signedDate` was effectively ignored. Other negative side effects could be described but I'll keep it short here.

# Proposed Solution
As `@resultBuilder`s can not be optional in Swift, a way was needed to provide a default verification policy that would not affect the policy that would be created further down the code depending on the payload's conformance to `ValidationTimePayload`. I have therefore created a dummy `EmptyPolicy`, which is always met.
The solution does not have any negative side effects, as a `RFC5280Policy` is added further down the code in any case. Only this time, it is either initialized with the `signedDate` of a `ValidationTimePayload` or the current date.