### PR TITLE
Remove NSString API usage

### DIFF
--- a/Sources/JWTKit/Utilities/Base64URL.swift
+++ b/Sources/JWTKit/Utilities/Base64URL.swift
@@ -6,8 +6,8 @@ import Foundation
 
 extension String {
     package func base64URLDecodedData() -> Data? {
-        var base64URL = replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
+        var base64URL = replacing("-", with: "+")
+            .replacing("_", with: "/")
 
         base64URL.append(contentsOf: "===".prefix((4 - (base64URL.count & 3)) & 3))
 

--- a/Sources/JWTKit/Utilities/Base64URL.swift
+++ b/Sources/JWTKit/Utilities/Base64URL.swift
@@ -6,12 +6,9 @@ import Foundation
 
 extension String {
     package func base64URLDecodedData() -> Data? {
-        var base64URL = replacing("-", with: "+")
-            .replacing("_", with: "/")
-
-        base64URL.append(contentsOf: "===".prefix((4 - (base64URL.count & 3)) & 3))
-
-        return Data(base64Encoded: base64URL)
+        var data = Data(self.utf8)
+        data.base64URLUnescape()
+        return Data(base64Encoded: data)
     }
 }
 


### PR DESCRIPTION
**These changes are now available in [5.4.1](https://github.com/vapor/jwt-kit/releases/tag/5.4.1)**


resolves #242 

Remove NSString API usage