### PR TITLE
Assert HMAC key size

### DIFF
--- a/Snippets/JWTKitExamples.swift
+++ b/Snippets/JWTKitExamples.swift
@@ -26,11 +26,11 @@ struct ExamplePayload: JWTPayload {
 
 // snippet.KEY_COLLECTION_ADD_HS256
 // Registers an HS256 (HMAC-SHA-256) signer.
-await keys.add(hmac: "secret", digestAlgorithm: .sha256)
+await keys.add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
 
 // snippet.KEY_COLLECTION_ADD_HS256_KID
 // Registers an HS256 (HMAC-SHA-256) signer with a key identifier.
-await keys.add(hmac: "secret", digestAlgorithm: .sha256, kid: "my-key")
+await keys.add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "my-key")
 
 // snippet.KEY_COLLECTION_CREATE_ES256
 let ecdsaPublicKey = "-----BEGIN PUBLIC KEY----- ... -----END PUBLIC KEY-----"
@@ -188,7 +188,9 @@ struct CustomParser: JWTParser {
 do {
     // snippet.CUSTOM_SIGNING
     let keyCollection = await JWTKeyCollection()
-        .add(hmac: "secret", digestAlgorithm: .sha256, parser: CustomParser(), serializer: CustomSerializer())
+        .add(
+            hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, parser: CustomParser(), serializer: CustomSerializer()
+        )
 
     let payload = ExamplePayload(sub: "vapor", exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000)), admin: false)
 
@@ -208,7 +210,7 @@ do {
     let serializer = DefaultJWTSerializer(jsonEncoder: encoder)
 
     let keyCollection = await JWTKeyCollection()
-        .add(hmac: "secret", digestAlgorithm: .sha256, parser: parser, serializer: serializer)
+        .add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, parser: parser, serializer: serializer)
     // snippet.end
     _ = keyCollection
 }

--- a/Sources/JWTKit/HMAC/HMACSigner.swift
+++ b/Sources/JWTKit/HMAC/HMACSigner.swift
@@ -13,7 +13,7 @@ struct HMACSigner<SHAType>: JWTAlgorithm where SHAType: HashFunction {
     init(key: SymmetricKey) {
         assert(
             key.bitCount >= SHAType.Digest.byteCount * 8,
-            "Key should be at least as large as the hash output: \(SHAType.Digest.byteCount) bytes"
+            "Key should be at least as large as the hash output: \(SHAType.Digest.byteCount) bytes. This will become a precondition in a future release."
         )
         self.key = key
         switch SHAType.self {

--- a/Sources/JWTKit/HMAC/HMACSigner.swift
+++ b/Sources/JWTKit/HMAC/HMACSigner.swift
@@ -11,6 +11,10 @@ struct HMACSigner<SHAType>: JWTAlgorithm where SHAType: HashFunction {
     let name: String
 
     init(key: SymmetricKey) {
+        assert(
+            key.bitCount >= SHAType.Digest.byteCount * 8,
+            "Key should be at least as large as the hash output: \(SHAType.Digest.byteCount) bytes"
+        )
         self.key = key
         switch SHAType.self {
         case is SHA256.Type:

--- a/Tests/JWTKitTests/ClaimTests.swift
+++ b/Tests/JWTKitTests/ClaimTests.swift
@@ -103,7 +103,7 @@ struct ClaimTests {
         let exp = ExpirationClaim(value: Date(timeIntervalSince1970: 2_000_000_000))
         let parser = DefaultJWTParser()
         let keyCollection = await JWTKeyCollection()
-            .add(hmac: .init(from: "secret".bytes), digestAlgorithm: .sha256, parser: parser)
+            .add(hmac: .init(from: "a-string-secret-at-least-256-bits-long".bytes), digestAlgorithm: .sha256, parser: parser)
         let jwt = try await keyCollection.sign(ExpirationPayload(exp: exp))
         let parsed = try parser.parse(jwt.bytes, as: ExpirationPayload.self)
         let header = parsed.header

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -45,11 +45,11 @@ struct JWTKitTests {
         }
 
         let keyCollection = await JWTKeyCollection()
-            .add(hmac: "secret", digestAlgorithm: .sha256)
+            .add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
 
         do {
             let jwt =
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ2YXBvciIsImV4cCI6NjQwOTIyMTEyMDAsImFkbWluIjp0cnVlfQ.lS5lpwfRNSZDvpGQk6x5JI1g40gkYCOWqbc3J_ghowo"
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ2YXBvciIsImV4cCI6NjQwOTIyMTEyMDAsImFkbWluIjp0cnVlfQ.023MpwVrTea_vZ7uzgZGN1dB-XK88BSC0oyLnQDbxSI"
             let payload = try await keyCollection.verify(jwt, as: TestPayload.self)
             #expect(payload.admin == true)
         }
@@ -69,9 +69,9 @@ struct JWTKitTests {
     @Test("Test Parsing")
     func parse() async throws {
         let data =
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImV4cCI6OTk5OTk5OTk5OTk5fQ.Ks7KcdjrlUTYaSNeAO5SzBla_sFCHkUh4vvJYn6q29U"
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImV4cCI6OTk5OTk5OTk5OTk5fQ.V3lYmAufL5fTJdyfMBcyEBBVW8ID3VZQOjuXx7MMzGg"
 
-        let test = try await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let test = try await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
             .verify(data, as: TestPayload.self)
 
         #expect(test.name == "John Doe")
@@ -100,10 +100,10 @@ struct JWTKitTests {
     @Test("Test Expiration")
     func expired() async throws {
         let data =
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImV4cCI6MX0.-x_DAYIg4R4R9oZssqgWyJP_oWO1ESj8DgKrGCk7i5o"
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjoxLCJuYW1lIjoiSm9obiBEb2UiLCJzdWIiOiIxMjM0NTY3ODkwIn0.bYNZS2F1wCl60yOAL2wYpfMHltZM4BMQnEjjdBnuOmM"
 
         do {
-            _ = try await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+            _ = try await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
                 .verify(data, as: TestPayload.self)
         } catch let error as JWTError {
             #expect(error.errorType == .claimVerificationFailure)
@@ -117,9 +117,9 @@ struct JWTKitTests {
     @Test("Test Expiration Decoding")
     func expirationDecoding() async throws {
         let data =
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIwMDAwMDAwMDB9.JgCO_GqUQnbS0z2hCxJLE9Tpt5SMoZObHBxzGBWuTYQ"
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIwMDAwMDAwMDB9.Aa64X3DI-9DwBJcBiviZxDX-tMLgbSGramzT4XInD_I"
 
-        let test = try await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let test = try await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
             .verify(data, as: ExpirationPayload.self)
         #expect(test.exp.value == Date(timeIntervalSince1970: 2_000_000_000))
     }
@@ -127,10 +127,10 @@ struct JWTKitTests {
     @Test("Test Signing")
     func sign() async throws {
         let data =
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImZvbyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImV4cCI6OTk5OTk5OTk5OTk5OTl9.Gf7leJ8i30LmMI7GBTpWDMXV60y1wkTOCOBudP9v9ms"
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjo5OTk5OTk5OTk5OTk5OSwibmFtZSI6IkpvaG4gRG9lIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.f90RL65oqClbSXw9JezmnMkS0IpsXo43za3iHE5MEqs"
         let keyCollection = await JWTKeyCollection()
             .add(
-                hmac: "bar",
+                hmac: "a-string-secret-at-least-256-bits-long",
                 digestAlgorithm: .sha256,
                 kid: "foo"
             )
@@ -456,7 +456,7 @@ struct JWTKitTests {
 
         let keyCollection = await JWTKeyCollection()
             .add(
-                hmac: "secret",
+                hmac: "a-string-secret-at-least-256-bits-long",
                 digestAlgorithm: .sha256,
                 parser: CustomParser(),
                 serializer: CustomSerializer()
@@ -511,7 +511,7 @@ struct JWTKitTests {
     }
 
     func testCustomHeaderFields() async throws {
-        let keyCollection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let keyCollection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
 
         let payload = TestPayload(
             sub: "vapor",
@@ -552,7 +552,7 @@ struct JWTKitTests {
         let keyCollection = await JWTKeyCollection()
             .add(
                 hmac: .init(key: .init(size: .bits256)),
-                digestAlgorithm: .sha384
+                digestAlgorithm: .sha256
             )
 
         let payload = TestPayload(
@@ -602,7 +602,7 @@ struct JWTKitTests {
 
     @Test("Test Custom Openbanking Header Fields")
     func sampleOpenbankingHeader() async throws {
-        let keyCollection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let keyCollection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
 
         // https://openbanking.atlassian.net/wiki/spaces/DZ/pages/937656404/Read+Write+Data+API+Specification+-+v3.1
         let customFields: JWTHeader = [
@@ -674,7 +674,7 @@ struct JWTKitTests {
 
     @Test("Test Custom Object Header")
     func customObjectHeader() async throws {
-        let keyCollection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let keyCollection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let customFields: JWTHeader = [
             "kid": "some-kid",
             "foo": ["bar": "baz"],
@@ -697,7 +697,7 @@ struct JWTKitTests {
     @Test("Test signing with iterating keys key collection")
     func testKeyCollectionIteration() async throws {
         let hmacToken = """
-            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImV4cCI6MjAwMDAwMDAwMH0.GW-OvOyauZXQeFuzFHRFL7saTXJrudGQ_qHtpbVWW9Y
+            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZG1pbiI6dHJ1ZSwiZXhwIjoyMDAwMDAwMDAwLCJuYW1lIjoiSm9obiBEb2UiLCJzdWIiOiIxMjM0NTY3ODkwIn0.dnDfvqV1v8z6NI4Pn-QMU2XIIrI8baoiTd2-mqd5snc
             """
         let ecdsaToken = """
             eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImV4cCI6MjAwMDAwMDAwMH0.bxLwoupZk9MW5Ys650FNn1CpedHBOPKLf9dRVjmETs3KUn4VIfcxSIK7tOEEeuExgpKssRxYEMpLlFyY6jsLRg
@@ -714,7 +714,7 @@ struct JWTKitTests {
         )
 
         let keyCollection = await JWTKeyCollection()
-            .add(hmac: "secret", digestAlgorithm: .sha256, kid: "hmac")
+            .add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "hmac")
             .add(ecdsa: ecdsaPrivateKey, kid: "ecdsa")
 
         let hmacVerified = try await keyCollection.verify(hmacToken, as: TestPayload.self)
@@ -856,8 +856,8 @@ struct JWTKitTests {
     @Test("Remove single key by kid")
     func testRemoveSingleKey() async throws {
         let keys = await JWTKeyCollection()
-            .add(hmac: "key-1", digestAlgorithm: .sha256, kid: "v1")
-            .add(hmac: "key-2", digestAlgorithm: .sha256, kid: "v2")
+            .add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v1")
+            .add(hmac: "another-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v2")
 
         let payload = TestPayload(
             sub: "vapor",
@@ -885,7 +885,7 @@ struct JWTKitTests {
     @Test("Remove non-existent key returns false")
     func testRemoveNonExistentKey() async throws {
         let keys = await JWTKeyCollection()
-            .add(hmac: "key-1", digestAlgorithm: .sha256, kid: "v1")
+            .add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v1")
 
         let removed = await keys.remove(kid: "non-existent")
         #expect(removed == false)
@@ -894,7 +894,7 @@ struct JWTKitTests {
     @Test("Remove default key clears default")
     func testRemoveDefaultKey() async throws {
         let keys = await JWTKeyCollection()
-            .add(hmac: "key-1", digestAlgorithm: .sha256)  // No kid = default
+            .add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)  // No kid = default
 
         let payload = TestPayload(
             sub: "vapor",
@@ -917,10 +917,10 @@ struct JWTKitTests {
     @Test("RemoveAll except specified keys")
     func testRemoveAllExcept() async throws {
         let keys = await JWTKeyCollection()
-            .add(hmac: "key-1", digestAlgorithm: .sha256, kid: "v1")
-            .add(hmac: "key-2", digestAlgorithm: .sha256, kid: "v2")
-            .add(hmac: "key-3", digestAlgorithm: .sha256, kid: "v3")
-            .add(hmac: "key-4", digestAlgorithm: .sha256, kid: "v4")
+            .add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v1")
+            .add(hmac: "another-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v2")
+            .add(hmac: "third-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v3")
+            .add(hmac: "fourth-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v4")
 
         let payload = TestPayload(
             sub: "vapor",
@@ -952,9 +952,9 @@ struct JWTKitTests {
     @Test("RemoveAll including default")
     func testRemoveAllWithDefault() async throws {
         let keys = await JWTKeyCollection()
-            .add(hmac: "key-0", digestAlgorithm: .sha256)
-            .add(hmac: "key-1", digestAlgorithm: .sha256, kid: "v1")
-            .add(hmac: "key-2", digestAlgorithm: .sha256, kid: "v2")
+            .add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
+            .add(hmac: "another-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v1")
+            .add(hmac: "third-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256, kid: "v2")
 
         let payload = TestPayload(
             sub: "vapor",

--- a/Tests/JWTKitTests/SignatureComparisonTests.swift
+++ b/Tests/JWTKitTests/SignatureComparisonTests.swift
@@ -4,14 +4,22 @@ import Testing
 
 @Suite("Signature comparison")
 struct SignatureComparisonTests {
-
     struct Payload: JWTPayload, Equatable {
         var sub: String
         func verify(using _: some JWTAlgorithm) throws {}
     }
 
     static func keys(_ digest: DigestAlgorithm) async -> JWTKeyCollection {
-        await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: digest)
+        switch digest {
+        case .sha256:
+            await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: digest)
+        case .sha384:
+            await JWTKeyCollection().add(hmac: "a-valid-string-secret-that-is-at-least-384-bits-long", digestAlgorithm: digest)
+        case .sha512:
+            await JWTKeyCollection().add(
+                hmac: "a-valid-string-secret-that-is-at-least-512-bits-long-which-is-very-long", digestAlgorithm: digest)
+        default: fatalError()
+        }
     }
 
     @Test("Valid signatures verify", arguments: [DigestAlgorithm.sha256, .sha384, .sha512])
@@ -32,7 +40,7 @@ struct SignatureComparisonTests {
         let last = parts[2].removeLast()
         parts[2].append(last == "A" ? "B" : "A")
 
-        await #expect(throws: (any Error).self) {
+        await #expect(throws: JWTError.signatureVerificationFailed) {
             _ = try await keys.verify(parts.joined(separator: "."), as: Payload.self)
         }
     }
@@ -54,7 +62,7 @@ struct SignatureComparisonTests {
     func wrongKeyOrDigestRejected() async throws {
         let token = try await Self.keys(.sha256).sign(Payload(sub: "1234567890"))
 
-        let otherSecret = await JWTKeyCollection().add(hmac: "other", digestAlgorithm: .sha256)
+        let otherSecret = await JWTKeyCollection().add(hmac: "another-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         await #expect(throws: (any Error).self) {
             _ = try await otherSecret.verify(token, as: Payload.self)
         }

--- a/Tests/JWTKitTests/VendorTokenTests.swift
+++ b/Tests/JWTKitTests/VendorTokenTests.swift
@@ -32,7 +32,7 @@ struct VendorTokenTests {
             nonce: "nonceValue"
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(throws: Never.self) {
@@ -62,7 +62,7 @@ struct VendorTokenTests {
             nonce: "nonceValue"
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(
@@ -97,7 +97,7 @@ struct VendorTokenTests {
             nonce: "nonceValue"
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(
@@ -127,7 +127,7 @@ struct VendorTokenTests {
             realUserStatus: .likelyReal
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(throws: Never.self) {
@@ -152,7 +152,7 @@ struct VendorTokenTests {
             realUserStatus: .likelyReal
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(
@@ -190,7 +190,7 @@ struct VendorTokenTests {
             version: "2.0"
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(throws: Never.self) {
@@ -221,7 +221,7 @@ struct VendorTokenTests {
             version: "2.0"
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(
@@ -257,7 +257,7 @@ struct VendorTokenTests {
             version: "2.0"
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(
@@ -291,7 +291,7 @@ struct VendorTokenTests {
             )
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(throws: Never.self) {
@@ -320,7 +320,7 @@ struct VendorTokenTests {
             )
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(
@@ -354,7 +354,7 @@ struct VendorTokenTests {
             )
         )
 
-        let collection = await JWTKeyCollection().add(hmac: "secret", digestAlgorithm: .sha256)
+        let collection = await JWTKeyCollection().add(hmac: "a-string-secret-at-least-256-bits-long", digestAlgorithm: .sha256)
         let jwt = try await collection.sign(token)
 
         await #expect(


### PR DESCRIPTION
According to [RFC 7518 section 3.2](https://datatracker.ietf.org/doc/html/rfc7518#section-3.2):
> A key of the same size as the hash output (for instance, 256 bits for "HS256") or larger MUST be used with this algorithm.

Since we cannot make the initialiser throwing, and since we might break some deployments if we used `precondition`, `assert` at least nudges people towards the correct key size, until we can enforce this with an error in a future major.