### PR TITLE
Make MLDSA APIs part of the public API

### DIFF
--- a/Benchmarks/Signing/Signing.swift
+++ b/Benchmarks/Signing/Signing.swift
@@ -1,6 +1,6 @@
 import Benchmark
 import Foundation
-@_spi(PostQuantum) import JWTKit
+import JWTKit
 import Utilities
 
 let benchmarks = {

--- a/Benchmarks/TokenLifecycle/TokenLifecycle.swift
+++ b/Benchmarks/TokenLifecycle/TokenLifecycle.swift
@@ -1,6 +1,6 @@
 import Benchmark
 import Foundation
-@_spi(PostQuantum) import JWTKit
+import JWTKit
 import Utilities
 
 let benchmarks = {

--- a/Benchmarks/Verifying/Verifying.swift
+++ b/Benchmarks/Verifying/Verifying.swift
@@ -1,6 +1,6 @@
 import Benchmark
 import Foundation
-@_spi(PostQuantum) import JWTKit
+import JWTKit
 import Utilities
 
 let benchmarks = {

--- a/README.md
+++ b/README.md
@@ -275,18 +275,12 @@ await keys.add(eddsa: privateKey)
 
 ## MLDSA
 
-Hidden behind the `@_spi(PostQuantum)` flag, JWTKit supports MLDSA (Module-Lattice-Based Digital Signature Algorithm), a post-quantum signature scheme based on the CRYSTALS-DILITHIUM algorithm. It is currently behind an SPI flag because, while the MLDSA signature scheme is [standardized by NIST](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.204.pdf), its [usage in JWT](https://www.ietf.org/archive/id/draft-ietf-cose-dilithium-04.html) is still in draft state, and, while unlikely, may change before being finalized. Therefore JWTKit reserves the ability to make breaking changes to this API until the usage of MLDSA in JWT is finalized.
+JWTKit supports MLDSA (Module-Lattice-Based Digital Signature Algorithm), a post-quantum signature scheme based on the CRYSTALS-DILITHIUM algorithm. You can learn more by reading [RFC 9964](https://datatracker.ietf.org/doc/rfc9964/).
 
 > [!NOTE]\
 > MLDSA requires macOS 26+.
 
-Currently, to use MLDSA, you must import JWTKit with the `@_spi(PostQuantum)` flag enabled:
-
-```swift
-@_spi(PostQuantum) import JWTKit
-```
-
-Then you can choose whether to use MLDSA65 or MLDSA87. Use them as follows:
+You can choose between MLDSA65 and MLDSA87. Use them as follows:
 
 ```swift
 // Initialize an MLDSA key with its seed

--- a/Snippets/JWTKitExamples.swift
+++ b/Snippets/JWTKitExamples.swift
@@ -1,6 +1,3 @@
-// snippet.MLDSA_IMPORT
-@_spi(PostQuantum) import JWTKit
-// snippet.end
 // snippet.KEY_COLLECTION
 import JWTKit
 

--- a/Sources/JWTKit/Docs.docc/index.md
+++ b/Sources/JWTKit/Docs.docc/index.md
@@ -163,16 +163,12 @@ You can create an EdDSA key using its coordinates:
 
 ## MLDSA
 
-Hidden behind the `@_spi(PostQuantum)` flag, JWTKit supports MLDSA (Module-Lattice-Based Digital Signature Algorithm), a post-quantum signature scheme based on the CRYSTALS-DILITHIUM algorithm. It is currently behind an SPI flag because, while the MLDSA signature scheme is [standardized by NIST](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.204.pdf), its [usage in JWT](https://www.ietf.org/archive/id/draft-ietf-cose-dilithium-04.html) is still in draft state, and, while unlikely, may change before being finalized. Therefore JWTKit reserves the ability to make breaking changes to this API until the usage of MLDSA in JWT is finalized.
+JWTKit supports MLDSA (Module-Lattice-Based Digital Signature Algorithm), a post-quantum signature scheme based on the CRYSTALS-DILITHIUM algorithm. You can learn more by reading [RFC 9964](https://datatracker.ietf.org/doc/rfc9964/).
 
 > Note:
 > MLDSA is only available on macOS 26+.
 
-Currently, to use MLDSA, you must import JWTKit with the `@_spi(PostQuantum)` flag enabled:
-
-@Snippet(path: "jwt-kit/Snippets/JWTKitExamples", slice: MLDSA_IMPORT)
-
-Then you can choose whether to use MLDSA65 or MLDSA87. Use them as follows:
+You can choose between MLDSA65 and MLDSA87. Use them as follows:
 
 @Snippet(path: "jwt-kit/Snippets/JWTKitExamples", slice: MLDSA)
 

--- a/Sources/JWTKit/MLDSA/JWTKeyCollection+MLDSA.swift
+++ b/Sources/JWTKit/MLDSA/JWTKeyCollection+MLDSA.swift
@@ -1,4 +1,27 @@
 extension JWTKeyCollection {
+    /// Adds an MLDSA key to the collection using an ``MLDSAKey``.
+    ///
+    /// This method incorporates an MLDSA (Module-Lattice-Based Digital Signature Algorithm) signer into the
+    /// collection. MLDSA is a post-quantum signature scheme, whose use in JWTs is defined by
+    /// [RFC 9964](https://datatracker.ietf.org/doc/rfc9964/).
+    ///
+    /// Usage Example:
+    /// ```
+    /// let privateKey = try MLDSA87PrivateKey(seedRepresentation: seed)
+    /// let collection = await JWTKeyCollection()
+    ///     .add(mldsa: privateKey)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - key: The ``MLDSAKey`` used for MLDSA signing. Passing a private key allows both signing and
+    ///          verifying, while passing a public key only allows verifying.
+    ///   - kid: An optional ``JWKIdentifier`` (Key ID). Providing this identifier allows the JWT `kid` header field
+    ///          to reference this specific signer.
+    ///   - parser: An optional custom parser that conforms to ``JWTParser``. If not specified,
+    ///          a ``DefaultJWTParser`` is used for parsing JWTs.
+    ///   - serializer: An optional custom serializer that conforms to ``JWTSerializer``. If not specified,
+    ///          a ``DefaultJWTSerializer`` is used for serializing JWTs.
+    /// - Returns: The same instance of the collection (`Self`), useful for chaining multiple configuration calls.
     @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
     @discardableResult
     public func add(

--- a/Sources/JWTKit/MLDSA/JWTKeyCollection+MLDSA.swift
+++ b/Sources/JWTKit/MLDSA/JWTKeyCollection+MLDSA.swift
@@ -1,5 +1,4 @@
 extension JWTKeyCollection {
-    @_spi(PostQuantum)
     @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
     @discardableResult
     public func add(

--- a/Sources/JWTKit/MLDSA/MLDSA.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA.swift
@@ -6,22 +6,50 @@ import FoundationEssentials
 import Foundation
 #endif
 
+/// Namespace for the MLDSA (Module-Lattice-Based Digital Signature Algorithm) signing algorithm.
+///
+/// MLDSA is a post-quantum signature scheme based on the CRYSTALS-DILITHIUM algorithm and standardized
+/// by NIST in [FIPS 204](https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.204.pdf). Its use in JOSE,
+/// and therefore in JWTs, is defined by [RFC 9964](https://datatracker.ietf.org/doc/rfc9964/).
+///
+/// Unlike the other algorithms supported by JWTKit, MLDSA keys are parameterised by the strength of the
+/// parameter set they use, which is expressed by the ``MLDSAType`` generic parameter. JWTKit supports the
+/// `MLDSA65` and `MLDSA87` parameter sets, which correspond to the `ML-DSA-65` and `ML-DSA-87`
+/// JWS algorithms respectively.
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public enum MLDSA: Sendable {}
 
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA {
+    /// A struct representing a public key used in MLDSA (Module-Lattice-Based Digital Signature Algorithm).
+    ///
+    /// MLDSA public keys are used to verify signatures. The parameter set the key belongs to is expressed by
+    /// the ``MLDSAType`` generic parameter, so a key is written as, for example, `MLDSA.PublicKey<MLDSA87>`.
+    /// The ``MLDSA65PublicKey`` and ``MLDSA87PublicKey`` typealiases are provided as a shorthand.
     public struct PublicKey<KeyType>: MLDSAKey where KeyType: MLDSAType {
+        /// The MLDSA parameter set this key belongs to.
         public typealias MLDSAType = KeyType
 
         typealias PublicKey = KeyType.PrivateKey.PublicKey
 
         let backing: any MLDSAPublicKey
 
+        /// Creates an ``MLDSA/PublicKey`` instance using the provided public key.
+        ///
+        /// This init constructs an ``MLDSA/PublicKey`` based on the corresponding SwiftCrypto public key,
+        /// such as `MLDSA65.PublicKey` or `MLDSA87.PublicKey`.
+        ///
+        /// - Parameter backing: The SwiftCrypto public key.
         public init(backing: some MLDSAPublicKey) {
             self.backing = backing
         }
 
+        /// Creates an ``MLDSA/PublicKey`` instance using the provided raw byte representation.
+        ///
+        /// - Parameter rawRepresentation: The raw bytes of the public key. Its length must match the one
+        ///   expected by the parameter set the key belongs to.
+        ///
+        /// - Throws: If the provided bytes aren't a valid public key for the key's parameter set.
         public init(rawRepresentation: some DataProtocol) throws {
             self.backing = try PublicKey(rawRepresentation: rawRepresentation)
         }
@@ -30,21 +58,47 @@ extension MLDSA {
 
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA {
+    /// A struct representing a private key used in MLDSA (Module-Lattice-Based Digital Signature Algorithm).
+    ///
+    /// MLDSA private keys are used to sign tokens. The parameter set the key belongs to is expressed by
+    /// the ``MLDSAType`` generic parameter, so a key is written as, for example, `MLDSA.PrivateKey<MLDSA87>`.
+    /// The ``MLDSA65PrivateKey`` and ``MLDSA87PrivateKey`` typealiases are provided as a shorthand.
     public struct PrivateKey<KeyType>: MLDSAKey where KeyType: MLDSAType {
+        /// The MLDSA parameter set this key belongs to.
         public typealias MLDSAType = KeyType
 
         typealias PrivateKey = KeyType.PrivateKey
 
         let backing: any MLDSAPrivateKey
 
+        /// The public key associated with this private key.
         public var publicKey: MLDSA.PublicKey<KeyType> {
             .init(backing: self.backing.publicKey)
         }
 
+        /// Creates an ``MLDSA/PrivateKey`` instance using the provided private key.
+        ///
+        /// This init constructs an ``MLDSA/PrivateKey`` based on the corresponding SwiftCrypto private key,
+        /// such as `MLDSA65.PrivateKey` or `MLDSA87.PrivateKey`.
+        ///
+        /// - Parameter backing: The SwiftCrypto private key.
         public init(backing: some MLDSAPrivateKey) {
             self.backing = backing
         }
 
+        /// Creates an ``MLDSA/PrivateKey`` instance using the seed it is derived from.
+        ///
+        /// MLDSA private keys are stored and transmitted as the 32-byte seed they are derived from, rather
+        /// than as the expanded key itself. The key is derived from the seed following the
+        /// `ML-DSA.KeyGen_internal` algorithm of FIPS 204.
+        ///
+        /// - Parameters:
+        ///   - seedRepresentation: The 32-byte seed the private key is derived from.
+        ///   - publicKey: An optional public key to check the derived key against. When provided, a consistency
+        ///     check is performed between it and the public key derived from the seed.
+        ///
+        /// - Throws: If the seed isn't valid for the key's parameter set, or if the provided public key doesn't
+        ///   match the one derived from the seed.
         public init(seedRepresentation: some DataProtocol, publicKey: KeyType.PrivateKey.PublicKey? = nil) throws {
             self.backing = try PrivateKey(seedRepresentation: seedRepresentation, publicKey: publicKey)
         }

--- a/Sources/JWTKit/MLDSA/MLDSA.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA.swift
@@ -6,7 +6,6 @@ import FoundationEssentials
 import Foundation
 #endif
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public enum MLDSA: Sendable {}
 

--- a/Sources/JWTKit/MLDSA/MLDSA65+MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA65+MLDSAKey.swift
@@ -1,21 +1,17 @@
 import Crypto
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA65.PublicKey: MLDSAPublicKey {
     public typealias MLDSAType = MLDSA65
 }
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA65.PrivateKey: MLDSAPrivateKey {
     public typealias MLDSAType = MLDSA65
 }
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public typealias MLDSA65PublicKey = MLDSA.PublicKey<MLDSA65>
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public typealias MLDSA65PrivateKey = MLDSA.PrivateKey<MLDSA65>

--- a/Sources/JWTKit/MLDSA/MLDSA65+MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA65+MLDSAKey.swift
@@ -10,8 +10,10 @@ extension MLDSA65.PrivateKey: MLDSAPrivateKey {
     public typealias MLDSAType = MLDSA65
 }
 
+/// An MLDSA public key using the `MLDSA65` parameter set, which signs and verifies `ML-DSA-65` tokens.
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public typealias MLDSA65PublicKey = MLDSA.PublicKey<MLDSA65>
 
+/// An MLDSA private key using the `MLDSA65` parameter set, which signs and verifies `ML-DSA-65` tokens.
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public typealias MLDSA65PrivateKey = MLDSA.PrivateKey<MLDSA65>

--- a/Sources/JWTKit/MLDSA/MLDSA87+MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA87+MLDSAKey.swift
@@ -10,8 +10,10 @@ extension MLDSA87.PrivateKey: MLDSAPrivateKey {
     public typealias MLDSAType = MLDSA87
 }
 
+/// An MLDSA public key using the `MLDSA87` parameter set, which signs and verifies `ML-DSA-87` tokens.
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public typealias MLDSA87PublicKey = MLDSA.PublicKey<MLDSA87>
 
+/// An MLDSA private key using the `MLDSA87` parameter set, which signs and verifies `ML-DSA-87` tokens.
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public typealias MLDSA87PrivateKey = MLDSA.PrivateKey<MLDSA87>

--- a/Sources/JWTKit/MLDSA/MLDSA87+MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA87+MLDSAKey.swift
@@ -1,21 +1,17 @@
 import Crypto
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA87.PublicKey: MLDSAPublicKey {
     public typealias MLDSAType = MLDSA87
 }
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA87.PrivateKey: MLDSAPrivateKey {
     public typealias MLDSAType = MLDSA87
 }
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public typealias MLDSA87PublicKey = MLDSA.PublicKey<MLDSA87>
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public typealias MLDSA87PrivateKey = MLDSA.PrivateKey<MLDSA87>

--- a/Sources/JWTKit/MLDSA/MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSAKey.swift
@@ -4,13 +4,11 @@ import FoundationEssentials
 import Foundation
 #endif
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public protocol MLDSAKey: Sendable {
     associatedtype MLDSAType: JWTKit.MLDSAType
 }
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public protocol MLDSAPublicKey: Sendable {
     associatedtype MLDSAType
@@ -23,7 +21,6 @@ public protocol MLDSAPublicKey: Sendable {
     ) -> Bool
 }
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public protocol MLDSAPrivateKey: Sendable {
     associatedtype MLDSAType

--- a/Sources/JWTKit/MLDSA/MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSAKey.swift
@@ -4,31 +4,92 @@ import FoundationEssentials
 import Foundation
 #endif
 
+/// This protocol represents a key that can be used for signing and verifying MLDSA signatures.
+/// Both ``MLDSA/PublicKey`` and ``MLDSA/PrivateKey`` conform to this protocol, which is what
+/// ``JWTKeyCollection/add(mldsa:kid:parser:serializer:)`` accepts.
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public protocol MLDSAKey: Sendable {
+    /// The MLDSA parameter set the key belongs to, such as `MLDSA65` or `MLDSA87`.
     associatedtype MLDSAType: JWTKit.MLDSAType
 }
 
+/// The requirements JWTKit needs from the underlying SwiftCrypto public key backing an ``MLDSA/PublicKey``.
+///
+/// You shouldn't need to conform your own types to this protocol: the SwiftCrypto `MLDSA65.PublicKey` and
+/// `MLDSA87.PublicKey` types already do.
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public protocol MLDSAPublicKey: Sendable {
+    /// The MLDSA parameter set the key belongs to.
     associatedtype MLDSAType
 
+    /// Creates a public key from its raw byte representation.
+    ///
+    /// - Parameter rawRepresentation: The raw bytes of the public key.
+    /// - Throws: If the provided bytes aren't a valid public key for the key's parameter set.
     init(rawRepresentation: some DataProtocol) throws
+
+    /// Raw bytes representation of the public key.
     var rawRepresentation: Data { get }
+
+    /// Verifies that the given signature is valid for the given data.
+    ///
+    /// - Parameters:
+    ///   - signature: The signature to verify.
+    ///   - data: The data the signature is expected to sign.
+    /// - Returns: Whether the signature is valid.
     func isValidSignature<S: DataProtocol, D: DataProtocol>(_ signature: S, for data: D) -> Bool
+
+    /// Verifies that the given signature is valid for the given data within the given context.
+    ///
+    /// - Parameters:
+    ///   - signature: The signature to verify.
+    ///   - data: The data the signature is expected to sign.
+    ///   - context: The context the signature was produced in. Signatures don't verify across different contexts.
+    /// - Returns: Whether the signature is valid.
     func isValidSignature<S: DataProtocol, D: DataProtocol, C: DataProtocol>(
         _ signature: S, for data: D, context: C
     ) -> Bool
 }
 
+/// The requirements JWTKit needs from the underlying SwiftCrypto private key backing an ``MLDSA/PrivateKey``.
+///
+/// You shouldn't need to conform your own types to this protocol: the SwiftCrypto `MLDSA65.PrivateKey` and
+/// `MLDSA87.PrivateKey` types already do.
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public protocol MLDSAPrivateKey: Sendable {
+    /// The MLDSA parameter set the key belongs to.
     associatedtype MLDSAType
+
+    /// The type of the public key associated with this private key.
     associatedtype PublicKey: MLDSAPublicKey
 
+    /// The 32-byte seed this private key is derived from.
     var seedRepresentation: Data { get }
+
+    /// The public key associated with this private key.
     var publicKey: PublicKey { get }
+
+    /// Creates a private key from the seed it is derived from.
+    ///
+    /// - Parameters:
+    ///   - seedRepresentation: The 32-byte seed the private key is derived from.
+    ///   - publicKey: An optional public key to check the derived key against.
+    /// - Throws: If the seed isn't valid, or if the provided public key doesn't match the derived one.
     init<D>(seedRepresentation: D, publicKey: PublicKey?) throws where D: DataProtocol
+
+    /// Signs the given data.
+    ///
+    /// - Parameter data: The data to sign.
+    /// - Returns: The signature.
+    /// - Throws: If the signature couldn't be produced.
     func signature<D: DataProtocol>(for data: D) throws -> Data
+
+    /// Signs the given data within the given context.
+    ///
+    /// - Parameters:
+    ///   - data: The data to sign.
+    ///   - context: The context to produce the signature in. Signatures don't verify across differing contexts.
+    /// - Returns: The signature.
+    /// - Throws: If the signature couldn't be produced.
     func signature<D: DataProtocol, C: DataProtocol>(for data: D, context: C) throws -> Data
 }

--- a/Sources/JWTKit/MLDSA/MLDSAType.swift
+++ b/Sources/JWTKit/MLDSA/MLDSAType.swift
@@ -1,18 +1,28 @@
 import Crypto
 
+/// An MLDSA parameter set, which determines the strength of the keys and signatures it produces.
+///
+/// JWTKit supports the two parameter sets vended by SwiftCrypto: `MLDSA65` and `MLDSA87`. Each one
+/// maps to the JWS algorithm of the same name registered by
+/// [RFC 9964](https://datatracker.ietf.org/doc/rfc9964/).
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public protocol MLDSAType {
+    /// The type of the private key belonging to this parameter set.
     associatedtype PrivateKey: MLDSAPrivateKey
 
+    /// The name of the JWS algorithm this parameter set corresponds to, used as the `alg` header field
+    /// of the tokens it signs.
     static var name: String { get }
 }
 
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA65: MLDSAType {
+    /// The name of the JWS algorithm this parameter set corresponds to.
     public static var name: String { "ML-DSA-65" }
 }
 
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA87: MLDSAType {
+    /// The name of the JWS algorithm this parameter set corresponds to.
     public static var name: String { "ML-DSA-87" }
 }

--- a/Sources/JWTKit/MLDSA/MLDSAType.swift
+++ b/Sources/JWTKit/MLDSA/MLDSAType.swift
@@ -1,6 +1,5 @@
 import Crypto
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 public protocol MLDSAType {
     associatedtype PrivateKey: MLDSAPrivateKey
@@ -8,13 +7,11 @@ public protocol MLDSAType {
     static var name: String { get }
 }
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA65: MLDSAType {
     public static var name: String { "ML-DSA-65" }
 }
 
-@_spi(PostQuantum)
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA87: MLDSAType {
     public static var name: String { "ML-DSA-87" }

--- a/Tests/JWTKitTests/MLDSATests.swift
+++ b/Tests/JWTKitTests/MLDSATests.swift
@@ -1,6 +1,6 @@
 import Crypto
 import Foundation
-@_spi(PostQuantum) import JWTKit
+import JWTKit
 import Testing
 
 @Suite("MLDSA Tests")


### PR DESCRIPTION
The ML-DSA JOSE proposal is not in draft state anymore (https://datatracker.ietf.org/doc/rfc9964/), so let's welcome it to our public API