### PR TITLE
Modernise and update to 6.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,8 @@ jobs:
       with_android: true
       with_linting: true
       with_windows: true
-      with_wasm: true
+      # Re-enable when SwiftCrypto builds on WASM
+      # with_wasm: true
       ios_scheme_name: jwt-kit
 
   submit-dependencies:
@@ -49,7 +50,7 @@ jobs:
     secrets: inherit
 
   foundation-linking:
-    uses: vapor/ci/.github/workflows/check-foundation-linking.yml@main
+    uses: vapor/ci/.github/workflows/check-foundation-linking.yml@727bb2695c01ea0876b91d1ba2ee139c0a0f64f7
     permissions:
       contents: read
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
       contents: read
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:noble
+    container: swift:6.3-noble
     steps:
       - name: Check out JWTKit
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: jwt-kit
       - name: Check out JWT provider
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: vapor/jwt
           path: jwt
@@ -32,15 +32,14 @@ jobs:
     permissions:
       contents: read
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    secrets: inherit
     with:
-      with_api_check: ${{ github.event_name == 'pull_request' }}
-      warnings_as_errors: true
-      with_linting: true
-      with_windows: false
       with_musl: true
       with_android: true
+      with_linting: true
+      with_windows: true
+      with_wasm: true
       ios_scheme_name: jwt-kit
-    secrets: inherit
 
   submit-dependencies:
     permissions:
@@ -48,3 +47,10 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     uses: vapor/ci/.github/workflows/submit-deps.yml@main
     secrets: inherit
+
+  foundation-linking:
+    uses: vapor/ci/.github/workflows/check-foundation-linking.yml@main
+    permissions:
+      contents: read
+    with:
+      swift_image: swift:6.3-noble

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(
@@ -25,13 +25,32 @@ let package = Package(
                 .product(name: "CryptoExtras", package: "swift-crypto"),
                 .product(name: "X509", package: "swift-certificates"),
                 .product(name: "Logging", package: "swift-log"),
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "JWTKitTests",
             dependencies: [
-                "JWTKit"
-            ]
+                .target(name: "JWTKit")
+            ],
+            swiftSettings: swiftSettings
         ),
     ]
 )
+
+var swiftSettings: [SwiftSetting] {
+    [
+        .treatAllWarnings(as: .error),
+        .strictMemorySafety(),
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault"),
+        .enableUpcomingFeature("MemberImportVisibility"),
+        .enableUpcomingFeature("InferIsolatedConformances"),
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+        .enableUpcomingFeature("ImmutableWeakCaptures"),
+        .enableExperimentalFeature("SuppressedAssociatedTypesWithDefaults"),
+        .enableExperimentalFeature("LifetimeDependence"),
+        .enableExperimentalFeature("Lifetimes"),
+        .enableUpcomingFeature("LifetimeDependence"),
+    ]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ var swiftSettings: [SwiftSetting] {
         .enableUpcomingFeature("InternalImportsByDefault"),
         .enableUpcomingFeature("MemberImportVisibility"),
         .enableUpcomingFeature("InferIsolatedConformances"),
-        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+        // .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
         .enableUpcomingFeature("ImmutableWeakCaptures"),
         .enableExperimentalFeature("SuppressedAssociatedTypesWithDefaults"),
         .enableExperimentalFeature("LifetimeDependence"),

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,8 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] {
     [
-        .treatAllWarnings(as: .error),
+        // Re-enable this on all platforms once we drop iOS 15, where JSONEn/Decoder are not Sendable
+        .treatAllWarnings(as: .error, .when(platforms: [.macOS, .linux, .windows, .android, .wasi, .openbsd])),
         .strictMemorySafety(),
         .enableUpcomingFeature("ExistentialAny"),
         .enableUpcomingFeature("InternalImportsByDefault"),

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/jwt-kit/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/jwt-kit/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
 <a href="https://codecov.io/github/vapor/jwt-kit"><img src="https://img.shields.io/codecov/c/github/vapor/jwt-kit?style=plastic&logo=codecov&label=codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift60up.svg" alt="Swift 6.0+"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift62up.svg" alt="Swift 6.2+"></a>
 <a href="https://www.swift.org/sswg/incubation-process.html"><img src="https://design.vapor.codes/images/sswg-graduated.svg" alt="SSWG Incubation Level: Graduated"></a>
 </p>
 <br>
@@ -20,7 +20,7 @@
 
 ### Supported Platforms
 
-JWTKit supports all platforms supported by Swift 6 and later.
+JWTKit supports all platforms supported by Swift 6.2 and later.
 
 ### Installation
 

--- a/Snippets/JWTKitExamples.swift
+++ b/Snippets/JWTKitExamples.swift
@@ -127,17 +127,17 @@ if #available(iOS 26, macOS 26, tvOS 26, watchOS 26, *) {
 extension DataProtocol {
     func base64URLDecodedBytes() -> [UInt8] {
         let string = String(decoding: self, as: UTF8.self)
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
+            .replacing("-", with: "+")
+            .replacing("_", with: "/")
         let padding = string.count % 4 == 0 ? "" : String(repeating: "=", count: 4 - string.count % 4)
         return [UInt8](Data(base64Encoded: string + padding) ?? Data())
     }
 
     func base64URLEncodedBytes() -> [UInt8] {
         Data(self).base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
+            .replacing("+", with: "-")
+            .replacing("/", with: "_")
+            .replacing("=", with: "")
             .utf8
             .map { UInt8($0) }
     }

--- a/Sources/JWTKit/Claims/BoolClaim.swift
+++ b/Sources/JWTKit/Claims/BoolClaim.swift
@@ -18,7 +18,7 @@ public struct BoolClaim: JWTClaim, Equatable, ExpressibleByStringLiteral, Expres
         self.value = value
     }
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let single = try decoder.singleValueContainer()
 
         do {

--- a/Sources/JWTKit/Claims/ExpirationClaim.swift
+++ b/Sources/JWTKit/Claims/ExpirationClaim.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// The "exp" (expiration time) claim identifies the expiration time on

--- a/Sources/JWTKit/Claims/IssuedAtClaim.swift
+++ b/Sources/JWTKit/Claims/IssuedAtClaim.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// The "iat" (issued at) claim identifies the time at which the JWT was

--- a/Sources/JWTKit/Claims/JWTClaim.swift
+++ b/Sources/JWTKit/Claims/JWTClaim.swift
@@ -21,13 +21,13 @@ extension JWTClaim where Value == String, Self: ExpressibleByStringLiteral {
 
 extension JWTClaim {
     /// See `Decodable`.
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let single = try decoder.singleValueContainer()
         try self.init(value: single.decode(Value.self))
     }
 
     /// See `Encodable`.
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var single = encoder.singleValueContainer()
         try single.encode(value)
     }

--- a/Sources/JWTKit/Claims/JWTMultiValueClaim.swift
+++ b/Sources/JWTKit/Claims/JWTMultiValueClaim.swift
@@ -43,7 +43,7 @@ extension JWTMultiValueClaim {
     ///   in a list of more than one. This implementation behaves according to
     ///   the semantics of the particular `Collection` type used as its value;
     ///   `Array` will preserve ordering and duplicates, `Set` will not.
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         do {
@@ -70,7 +70,7 @@ extension JWTMultiValueClaim {
     /// - Warning: If the claim has zero values, this implementation will encode
     ///   an inefficient zero-element representation. See the notes regarding
     ///   this on `init(from decoder:)` above.
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self.value.first {
@@ -100,7 +100,7 @@ private struct CollectionOfOneDecoder<T>: Decoder, UnkeyedDecodingContainer wher
     var currentIndex: Int = 0
 
     /// We are our own unkeyed decoding container.
-    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+    func unkeyedContainer() throws -> any UnkeyedDecodingContainer {
         return self
     }
 
@@ -137,7 +137,7 @@ private struct CollectionOfOneDecoder<T>: Decoder, UnkeyedDecodingContainer wher
     // user info and we just fail instantly if asked for anything other than an unnested unkeyed container. The count
     // of the unkeyed container is always exactly one.
 
-    var codingPath: [CodingKey] = []
+    var codingPath: [any CodingKey] = []
     var userInfo: [CodingUserInfoKey: Any] = [:]
     var isAtEnd: Bool { currentIndex != 0 }
     var count: Int? = 1
@@ -146,7 +146,7 @@ private struct CollectionOfOneDecoder<T>: Decoder, UnkeyedDecodingContainer wher
         throw self.unsupportedError
     }
 
-    func singleValueContainer() throws -> SingleValueDecodingContainer {
+    func singleValueContainer() throws -> any SingleValueDecodingContainer {
         throw self.unsupportedError
     }
 
@@ -154,11 +154,11 @@ private struct CollectionOfOneDecoder<T>: Decoder, UnkeyedDecodingContainer wher
         throw self.unsupportedError
     }
 
-    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+    mutating func nestedUnkeyedContainer() throws -> any UnkeyedDecodingContainer {
         throw self.unsupportedError
     }
 
-    mutating func superDecoder() throws -> Decoder {
+    mutating func superDecoder() throws -> any Decoder {
         throw self.unsupportedError
     }
 }

--- a/Sources/JWTKit/Claims/JWTUnixEpochClaim.swift
+++ b/Sources/JWTKit/Claims/JWTUnixEpochClaim.swift
@@ -1,20 +1,20 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public protocol JWTUnixEpochClaim: JWTClaim where Value == Date {}
 
 extension JWTUnixEpochClaim {
     /// See `Decodable`.
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         try self.init(value: container.decode(Date.self))
     }
 
     /// See `Encodable`.
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(self.value)
     }

--- a/Sources/JWTKit/Claims/LocaleClaim.swift
+++ b/Sources/JWTKit/Claims/LocaleClaim.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public struct LocaleClaim: JWTClaim, Equatable, ExpressibleByStringLiteral {
@@ -18,13 +18,13 @@ public struct LocaleClaim: JWTClaim, Equatable, ExpressibleByStringLiteral {
     }
 
     /// See `Decodable`.
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         try self.init(value: Locale(identifier: container.decode(String.self)))
     }
 
     /// See `Encodable`.
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(value.identifier)
     }

--- a/Sources/JWTKit/Claims/NotBeforeClaim.swift
+++ b/Sources/JWTKit/Claims/NotBeforeClaim.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// The "nbf" (not before) claim identifies the time before which the JWT

--- a/Sources/JWTKit/ECDSA/ECDSA.swift
+++ b/Sources/JWTKit/ECDSA/ECDSA.swift
@@ -1,10 +1,11 @@
 import Crypto
+import SwiftASN1
 import X509
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public enum ECDSA: Sendable {}

--- a/Sources/JWTKit/ECDSA/ECDSAKeyTypes.swift
+++ b/Sources/JWTKit/ECDSA/ECDSAKeyTypes.swift
@@ -1,10 +1,10 @@
-import Crypto
-import X509
+public import Crypto
+public import X509
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// A typealias representing the parameters of an ECDSA (Elliptic Curve Digital Signature Algorithm) key.

--- a/Sources/JWTKit/ECDSA/P256+CurveType.swift
+++ b/Sources/JWTKit/ECDSA/P256+CurveType.swift
@@ -1,9 +1,10 @@
-import Crypto
+public import Crypto
+import X509
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 extension P256: ECDSACurveType {

--- a/Sources/JWTKit/ECDSA/P384+CurveType.swift
+++ b/Sources/JWTKit/ECDSA/P384+CurveType.swift
@@ -1,9 +1,10 @@
-import Crypto
+public import Crypto
+import X509
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 extension P384: ECDSACurveType {

--- a/Sources/JWTKit/ECDSA/P521+CurveType.swift
+++ b/Sources/JWTKit/ECDSA/P521+CurveType.swift
@@ -1,9 +1,10 @@
-import Crypto
+public import Crypto
+import X509
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 extension P521: ECDSACurveType {

--- a/Sources/JWTKit/EdDSA/EdDSA.swift
+++ b/Sources/JWTKit/EdDSA/EdDSA.swift
@@ -1,9 +1,10 @@
-import Crypto
+public import Crypto
+import CryptoExtras
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// Namespace for the EdDSA (Edwards-curve Digital Signature Algorithm) signing algorithm.

--- a/Sources/JWTKit/HMAC/HMAC.swift
+++ b/Sources/JWTKit/HMAC/HMAC.swift
@@ -1,9 +1,9 @@
-@preconcurrency import Crypto
+public import Crypto
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public struct HMACKey: Sendable {

--- a/Sources/JWTKit/HMAC/HMACSigner.swift
+++ b/Sources/JWTKit/HMAC/HMACSigner.swift
@@ -1,4 +1,4 @@
-@preconcurrency import Crypto
+import Crypto
 
 #if !canImport(Darwin)
 import FoundationEssentials

--- a/Sources/JWTKit/JWK/JWK.swift
+++ b/Sources/JWTKit/JWK/JWK.swift
@@ -1,5 +1,8 @@
-import struct Foundation.Data
-import class Foundation.JSONDecoder
+#if !canImport(Darwin)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// A JSON Web Key.
 ///

--- a/Sources/JWTKit/JWK/JWKIdentifier.swift
+++ b/Sources/JWTKit/JWK/JWKIdentifier.swift
@@ -7,12 +7,12 @@ public struct JWKIdentifier: Hashable, Equatable, Sendable {
 }
 
 extension JWKIdentifier: Codable {
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         try self.init(string: container.decode(String.self))
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(self.string)
     }

--- a/Sources/JWTKit/JWK/JWKSigner.swift
+++ b/Sources/JWTKit/JWK/JWKSigner.swift
@@ -1,3 +1,5 @@
+import CryptoExtras
+
 actor JWKSigner: Sendable {
     let jwk: JWK
     let parser: any JWTParser
@@ -41,7 +43,7 @@ extension JWK {
                 throw JWTError.invalidJWK(reason: "Missing RSA primitives")
             }
 
-            let rsaKey: RSAKey =
+            let rsaKey: any RSAKey =
                 if let privateExponent = self.privateExponent {
                     if let prime1, let prime2 {
                         try Insecure.RSA.PrivateKey(

--- a/Sources/JWTKit/JWTAlgorithm.swift
+++ b/Sources/JWTKit/JWTAlgorithm.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// A protocol defining the necessary functionality for a JWT (JSON Web Token) algorithm.

--- a/Sources/JWTKit/JWTError.swift
+++ b/Sources/JWTKit/JWTError.swift
@@ -56,7 +56,7 @@ public struct JWTError: Error, Sendable, Equatable {
         fileprivate let errorType: ErrorType
         fileprivate let name: String?
         fileprivate let reason: String?
-        fileprivate let underlying: Error?
+        fileprivate let underlying: (any Error)?
         fileprivate let kid: JWKIdentifier?
         fileprivate let identifier: String?
         fileprivate let failedClaim: (any JWTClaim)?
@@ -67,7 +67,7 @@ public struct JWTError: Error, Sendable, Equatable {
             errorType: ErrorType,
             name: String? = nil,
             reason: String? = nil,
-            underlying: Error? = nil,
+            underlying: (any Error)? = nil,
             kid: JWKIdentifier? = nil,
             identifier: String? = nil,
             failedClaim: (any JWTClaim)? = nil,
@@ -113,7 +113,7 @@ public struct JWTError: Error, Sendable, Equatable {
         .init(backing: .init(errorType: .claimVerificationFailure, reason: reason, failedClaim: failedClaim))
     }
 
-    public static func signingAlgorithmFailure(_ error: Error) -> Self {
+    public static func signingAlgorithmFailure(_ error: any Error) -> Self {
         .init(backing: .init(errorType: .signingAlgorithmFailure, underlying: error))
     }
 

--- a/Sources/JWTKit/JWTHeader.swift
+++ b/Sources/JWTKit/JWTHeader.swift
@@ -30,14 +30,14 @@ extension JWTHeader: ExpressibleByDictionaryLiteral {
 }
 
 extension JWTHeader: Codable {
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         for (key, value) in self.fields {
             try container.encode(value, forKey: .custom(name: key))
         }
     }
 
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.fields = try Set(container.allKeys)

--- a/Sources/JWTKit/JWTKeyCollection.swift
+++ b/Sources/JWTKit/JWTKeyCollection.swift
@@ -1,9 +1,9 @@
-import Logging
+public import Logging
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// A collection of JWT and JWK signers for handling JSON Web Tokens (JWTs).

--- a/Sources/JWTKit/JWTParser.swift
+++ b/Sources/JWTKit/JWTParser.swift
@@ -1,11 +1,11 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public protocol JWTParser: Sendable {
-    var jsonDecoder: JWTJSONDecoder { get set }
+    var jsonDecoder: any JWTJSONDecoder { get set }
     func parse<Payload>(_ token: some DataProtocol, as: Payload.Type) throws -> (
         header: JWTHeader, payload: Payload, signature: Data
     ) where Payload: JWTPayload
@@ -44,9 +44,9 @@ extension JWTParser {
 }
 
 public struct DefaultJWTParser: JWTParser {
-    public var jsonDecoder: JWTJSONDecoder = .defaultForJWT
+    public var jsonDecoder: any JWTJSONDecoder = .defaultForJWT
 
-    public init(jsonDecoder: JWTJSONDecoder = .defaultForJWT) {
+    public init(jsonDecoder: any JWTJSONDecoder = .defaultForJWT) {
         self.jsonDecoder = jsonDecoder
     }
 

--- a/Sources/JWTKit/JWTSerializer.swift
+++ b/Sources/JWTKit/JWTSerializer.swift
@@ -1,9 +1,10 @@
+import SwiftASN1
 import X509
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public protocol JWTSerializer: Sendable {
@@ -12,7 +13,7 @@ public protocol JWTSerializer: Sendable {
 }
 
 extension JWTSerializer {
-    public func makeHeader(from header: JWTHeader, key: JWTAlgorithm) async throws -> JWTHeader {
+    public func makeHeader(from header: JWTHeader, key: any JWTAlgorithm) async throws -> JWTHeader {
         var newHeader = header
 
         newHeader.alg = newHeader.alg ?? key.name
@@ -53,9 +54,9 @@ extension JWTSerializer {
 }
 
 public struct DefaultJWTSerializer: JWTSerializer {
-    public var jsonEncoder: JWTJSONEncoder = .defaultForJWT
+    public var jsonEncoder: any JWTJSONEncoder = .defaultForJWT
 
-    public init(jsonEncoder: JWTJSONEncoder = .defaultForJWT) {
+    public init(jsonEncoder: any JWTJSONEncoder = .defaultForJWT) {
         self.jsonEncoder = jsonEncoder
     }
 

--- a/Sources/JWTKit/JWTSigner.swift
+++ b/Sources/JWTKit/JWTSigner.swift
@@ -6,7 +6,7 @@ import Foundation
 
 /// A JWT signer.
 final class JWTSigner: Sendable {
-    let algorithm: JWTAlgorithm
+    let algorithm: any JWTAlgorithm
 
     let parser: any JWTParser
     let serializer: any JWTSerializer

--- a/Sources/JWTKit/MLDSA/MLDSA.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA.swift
@@ -1,9 +1,9 @@
 import CryptoExtras
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// Namespace for the MLDSA (Module-Lattice-Based Digital Signature Algorithm) signing algorithm.

--- a/Sources/JWTKit/MLDSA/MLDSA65+MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA65+MLDSAKey.swift
@@ -1,4 +1,4 @@
-import Crypto
+public import Crypto
 
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA65.PublicKey: MLDSAPublicKey {

--- a/Sources/JWTKit/MLDSA/MLDSA87+MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSA87+MLDSAKey.swift
@@ -1,4 +1,4 @@
-import Crypto
+public import Crypto
 
 @available(iOS 26.0, macOS 26.0, watchOS 26.0, tvOS 26.0, *)
 extension MLDSA87.PublicKey: MLDSAPublicKey {

--- a/Sources/JWTKit/MLDSA/MLDSAError.swift
+++ b/Sources/JWTKit/MLDSA/MLDSAError.swift
@@ -1,4 +1,4 @@
 enum MLDSAError: Error {
     case noPrivateKey
-    case failedToSign(Error)
+    case failedToSign(any Error)
 }

--- a/Sources/JWTKit/MLDSA/MLDSAKey.swift
+++ b/Sources/JWTKit/MLDSA/MLDSAKey.swift
@@ -1,7 +1,7 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// This protocol represents a key that can be used for signing and verifying MLDSA signatures.

--- a/Sources/JWTKit/MLDSA/MLDSAType.swift
+++ b/Sources/JWTKit/MLDSA/MLDSAType.swift
@@ -1,4 +1,4 @@
-import Crypto
+public import Crypto
 
 /// An MLDSA parameter set, which determines the strength of the keys and signatures it produces.
 ///

--- a/Sources/JWTKit/RSA/RSA.swift
+++ b/Sources/JWTKit/RSA/RSA.swift
@@ -1,11 +1,12 @@
 import Crypto
-import CryptoExtras
+public import CryptoExtras
+import SwiftASN1
 import X509
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 extension Insecure {

--- a/Sources/JWTKit/RSA/RSAError.swift
+++ b/Sources/JWTKit/RSA/RSAError.swift
@@ -1,7 +1,7 @@
 enum RSAError: Error {
     case privateKeyRequired
     case publicKeyRequired
-    case signFailure(_ error: Error)
+    case signFailure(_ error: any Error)
     case keyInitializationFailure
     case keySizeTooSmall
 }

--- a/Sources/JWTKit/Utilities/Base64URL.swift
+++ b/Sources/JWTKit/Utilities/Base64URL.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+package import FoundationEssentials
 #else
-import Foundation
+package import Foundation
 #endif
 
 extension String {

--- a/Sources/JWTKit/Utilities/CustomizedJSONCoders.swift
+++ b/Sources/JWTKit/Utilities/CustomizedJSONCoders.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public protocol JWTJSONDecoder: Sendable {

--- a/Sources/JWTKit/Utilities/Utilities.swift
+++ b/Sources/JWTKit/Utilities/Utilities.swift
@@ -1,20 +1,20 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 extension DataProtocol {
     public func copyBytes() -> [UInt8] {
         if let array = self.withContiguousStorageIfAvailable({ buffer in
-            [UInt8](buffer)
+            unsafe [UInt8](buffer)
         }) {
             return array
         } else {
             let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: self.count)
-            self.copyBytes(to: buffer)
-            defer { buffer.deallocate() }
-            return [UInt8](buffer)
+            unsafe self.copyBytes(to: buffer)
+            defer { unsafe buffer.deallocate() }
+            return unsafe [UInt8](buffer)
         }
     }
 }

--- a/Sources/JWTKit/Vendor/AppleIdentityToken.swift
+++ b/Sources/JWTKit/Vendor/AppleIdentityToken.swift
@@ -117,7 +117,7 @@ extension AppleIdentityToken {
             self.rawValue = rawValue
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let value = try decoder.singleValueContainer().decode(Status.self)
             switch value {
             case .unsupported: self = .unsupported
@@ -126,7 +126,7 @@ extension AppleIdentityToken {
             }
         }
 
-        public func encode(to encoder: Encoder) throws {
+        public func encode(to encoder: any Encoder) throws {
             var container = encoder.singleValueContainer()
             switch self {
             case .unsupported: try container.encode(Status.unsupported)

--- a/Sources/JWTKit/Vendor/FirebaseAuthIdentityToken.swift
+++ b/Sources/JWTKit/Vendor/FirebaseAuthIdentityToken.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public struct FirebaseAuthIdentityToken: JWTPayload {

--- a/Sources/JWTKit/X5C/EmptyPolicy.swift
+++ b/Sources/JWTKit/X5C/EmptyPolicy.swift
@@ -1,5 +1,5 @@
-import SwiftASN1
-import X509
+public import SwiftASN1
+public import X509
 
 /// This Policy acts as a placeholder. Its result is always positive.
 public struct EmptyPolicy: VerifierPolicy {

--- a/Sources/JWTKit/X5C/ValidationTimePayload.swift
+++ b/Sources/JWTKit/X5C/ValidationTimePayload.swift
@@ -1,7 +1,7 @@
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// A protocol defining the requirements for payloads that include a validation time.

--- a/Sources/JWTKit/X5C/X5CVerifier.swift
+++ b/Sources/JWTKit/X5C/X5CVerifier.swift
@@ -1,9 +1,11 @@
-@_spi(FixedExpiryValidationTime) import X509
+import CryptoExtras
+import SwiftASN1
+@_spi(FixedExpiryValidationTime) public import X509
 
 #if !canImport(Darwin)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// An object for verifying JWS tokens that contain the `x5c` header parameter
@@ -60,7 +62,7 @@ public struct X5CVerifier: Sendable {
     /// - Returns: A `X509.VerificationResult` indicating the result of the verification.
     public func verifyChain(
         certificates: [String],
-        policy: () throws -> some VerifierPolicy = { RFC5280Policy() }
+        policy: sending () throws -> some VerifierPolicy = { RFC5280Policy() }
     ) async throws -> X509.CertificateValidationResult {
         let certificates = try certificates.map { try Certificate(pemEncoded: $0) }
         return try await verifyChain(certificates: certificates, policy: policy)
@@ -74,7 +76,7 @@ public struct X5CVerifier: Sendable {
     /// - Returns: A `X509.VerificationResult` indicating the result of the verification.
     public func verifyChain(
         certificates: [Certificate],
-        @PolicyBuilder policy: () throws -> some VerifierPolicy = { RFC5280Policy() }
+        @PolicyBuilder policy: sending () throws -> some VerifierPolicy = { RFC5280Policy() }
     ) async throws -> X509.CertificateValidationResult {
         let untrustedChain = CertificateStore(certificates)
         var verifier = try Verifier(rootCertificates: trustedStore, policy: policy)
@@ -141,7 +143,7 @@ public struct X5CVerifier: Sendable {
         _ token: some DataProtocol,
         as _: Payload.Type = Payload.self,
         jsonDecoder: any JWTJSONDecoder,
-        @PolicyBuilder policy: () throws -> some VerifierPolicy = { EmptyPolicy() }
+        @PolicyBuilder policy: sending () throws -> some VerifierPolicy = { EmptyPolicy() }
     ) async throws -> Payload
     where Payload: JWTPayload {
         // Parse the JWS header to get the header
@@ -175,7 +177,7 @@ public struct X5CVerifier: Sendable {
         let date: Date
         // Some JWT implementations have the sign date in the payload.
         // If it's such a payload, we'll use that date for validation
-        if let validationTimePayload = payload as? ValidationTimePayload {
+        if let validationTimePayload = payload as? any ValidationTimePayload {
             date = validationTimePayload.signedDate
         } else {
             date = Date()

--- a/Tests/JWTKitTests/EdDSATests.swift
+++ b/Tests/JWTKitTests/EdDSATests.swift
@@ -1,6 +1,11 @@
 #if canImport(Testing)
 import Testing
 import JWTKit
+#if !canImport(Darwin)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite("EdDSA Tests")
 struct EdDSATests {

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -7,6 +7,7 @@ import X509
 import FoundationEssentials
 #else
 import Foundation
+import Crypto
 #endif
 
 @Suite("JWTKit Tests")
@@ -257,8 +258,8 @@ struct JWTKitTests {
             try await keyCollection.getKey()
         }
 
-        let a: JWTAlgorithm
-        let b: JWTAlgorithm
+        let a: any JWTAlgorithm
+        let b: any JWTAlgorithm
 
         do {
             a = try await keyCollection.getKey(for: "a")
@@ -414,7 +415,7 @@ struct JWTKitTests {
     @Test("Test B64 Custom Serialising")
     func customSerialisingWithB64Header() async throws {
         struct CustomSerializer: JWTSerializer {
-            var jsonEncoder: JWTJSONEncoder = .defaultForJWT
+            var jsonEncoder: any JWTJSONEncoder = .defaultForJWT
 
             func serialize(_ payload: some JWTPayload, header: JWTHeader) throws -> Data {
                 if header.b64?.asBool == true {
@@ -426,7 +427,7 @@ struct JWTKitTests {
         }
 
         struct CustomParser: JWTParser {
-            var jsonDecoder: JWTJSONDecoder = .defaultForJWT
+            var jsonDecoder: any JWTJSONDecoder = .defaultForJWT
 
             func parse<Payload>(_ token: some DataProtocol, as _: Payload.Type) throws -> (
                 header: JWTHeader, payload: Payload, signature: Data

--- a/Tests/JWTKitTests/JWTKitTests.swift
+++ b/Tests/JWTKitTests/JWTKitTests.swift
@@ -2,12 +2,12 @@
 import Testing
 import JWTKit
 import X509
+import Crypto
 
 #if !canImport(Darwin)
 import FoundationEssentials
 #else
 import Foundation
-import Crypto
 #endif
 
 @Suite("JWTKit Tests")

--- a/Tests/JWTKitTests/RSATests.swift
+++ b/Tests/JWTKitTests/RSATests.swift
@@ -2,6 +2,11 @@
 import Testing
 import JWTKit
 import CryptoExtras
+#if !canImport(Darwin)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite("RSA Tests")
 struct RSATests {

--- a/Tests/JWTKitTests/X5CTests.swift
+++ b/Tests/JWTKitTests/X5CTests.swift
@@ -201,7 +201,7 @@ struct X5CTests {
         do {
             payload = try await verifier.verifyJWS(token, as: StoreKitPayload.self, jsonDecoder: jsonDecoder)
         } catch {
-            Issue.record("Failed with error: \(error.localizedDescription)")
+            Issue.record("Failed with error: \(error)")
         }
 
         let data = try #require(payload).data

--- a/Tests/JWTKitTests/X5CTests.swift
+++ b/Tests/JWTKitTests/X5CTests.swift
@@ -10,6 +10,8 @@ import Foundation
 #endif
 
 import Crypto
+import SwiftASN1
+import CryptoExtras
 
 /// Test the x5c verification abilities of JWTSigners.
 ///


### PR DESCRIPTION
**These changes are now available in [5.7.0](https://github.com/vapor/jwt-kit/releases/tag/5.7.0)**


Switches to Swift 6.2 and addresses the points in https://github.com/orgs/vapor/projects/17